### PR TITLE
Add dynamic top level attributes to extend the descriptor file syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 project/*
 .idea
 target/*

--- a/src/main/java/com/purbon/kafka/topology/TopologyCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyCustomDeserializer.java
@@ -1,0 +1,58 @@
+package com.purbon.kafka.topology;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.purbon.kafka.topology.model.Project;
+import com.purbon.kafka.topology.model.Topology;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Iterator;
+
+public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
+
+  protected TopologyCustomDeserializer() {
+    this(null);
+  }
+
+  protected TopologyCustomDeserializer(Class<?> clazz) {
+    super(clazz);
+  }
+
+  @Override
+  public Topology deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+
+    JsonNode rootNode = parser.getCodec().readTree(parser);
+
+    JsonNode projects = rootNode.get("projects");
+    Topology topology = new Topology();
+
+    for(int i=0; i < projects.size(); i++) {
+      JsonNode node = projects.get(i);
+      Project project = parser.getCodec().treeToValue(node, Project.class);
+      topology.addProject(project);
+    }
+
+    ArrayList<String> excludeAttributes = new ArrayList<>();
+    excludeAttributes.add("projects");
+    excludeAttributes.add("team");
+    excludeAttributes.add("source");
+
+    Map<String, String> others = new HashMap<>();
+
+    Iterator<String> fieldNames = rootNode.fieldNames();
+    while(fieldNames.hasNext()) {
+        String fieldName = fieldNames.next();
+        if (!excludeAttributes.contains(fieldName)) {
+          others.put(fieldName, rootNode.get(fieldName).asText());
+        }
+    }
+    topology.addDynamicAttrs(others);
+    topology.setTeam(rootNode.get("team").asText());
+    topology.setSource(rootNode.get("source").asText());
+    return topology;
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/TopologyCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyCustomDeserializer.java
@@ -8,12 +8,13 @@ import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topology;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Iterator;
 
 public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
+
+  public static final String PROJECTS_KEY = "projects";
+  public static final String TEAM_KEY = "team";
+  public static final String SOURCE_KEY = "source";
 
   protected TopologyCustomDeserializer() {
     this(null);
@@ -28,7 +29,7 @@ public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
 
     JsonNode rootNode = parser.getCodec().readTree(parser);
 
-    JsonNode projects = rootNode.get("projects");
+    JsonNode projects = rootNode.get(PROJECTS_KEY);
     Topology topology = new Topology();
 
     for(int i=0; i < projects.size(); i++) {
@@ -38,9 +39,9 @@ public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
     }
 
     ArrayList<String> excludeAttributes = new ArrayList<>();
-    excludeAttributes.add("projects");
-    excludeAttributes.add("team");
-    excludeAttributes.add("source");
+    excludeAttributes.add(PROJECTS_KEY);
+    excludeAttributes.add(TEAM_KEY);
+    excludeAttributes.add(SOURCE_KEY);
 
     Iterator<String> fieldNames = rootNode.fieldNames();
     while(fieldNames.hasNext()) {
@@ -49,8 +50,8 @@ public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
           topology.addOther(fieldName, rootNode.get(fieldName).asText());
         }
     }
-    topology.setTeam(rootNode.get("team").asText());
-    topology.setSource(rootNode.get("source").asText());
+    topology.setTeam(rootNode.get(TEAM_KEY).asText());
+    topology.setSource(rootNode.get(SOURCE_KEY).asText());
     return topology;
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/TopologyCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyCustomDeserializer.java
@@ -9,6 +9,7 @@ import com.purbon.kafka.topology.model.Topology;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Iterator;
 
@@ -41,16 +42,13 @@ public class TopologyCustomDeserializer extends StdDeserializer<Topology> {
     excludeAttributes.add("team");
     excludeAttributes.add("source");
 
-    Map<String, String> others = new HashMap<>();
-
     Iterator<String> fieldNames = rootNode.fieldNames();
     while(fieldNames.hasNext()) {
         String fieldName = fieldNames.next();
         if (!excludeAttributes.contains(fieldName)) {
-          others.put(fieldName, rootNode.get(fieldName).asText());
+          topology.addOther(fieldName, rootNode.get(fieldName).asText());
         }
     }
-    topology.addDynamicAttrs(others);
     topology.setTeam(rootNode.get("team").asText());
     topology.setSource(rootNode.get("source").asText());
     return topology;

--- a/src/main/java/com/purbon/kafka/topology/TopologySerdes.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologySerdes.java
@@ -2,6 +2,7 @@ package com.purbon.kafka.topology;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.purbon.kafka.topology.model.Project;
@@ -17,6 +18,9 @@ public class TopologySerdes {
 
   public TopologySerdes() {
     mapper = new ObjectMapper(new YAMLFactory());
+    SimpleModule module = new SimpleModule();
+    module.addDeserializer(Topology.class, new TopologyCustomDeserializer());
+    mapper.registerModule(module);
     mapper.registerModule(new Jdk8Module());
     mapper.findAndRegisterModules();
   }

--- a/src/main/java/com/purbon/kafka/topology/model/Topology.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Topology.java
@@ -13,11 +13,13 @@ public class Topology {
   private Map<String, String> others;
 
   private List<Project> projects;
+  private List<String> order;
 
   public Topology() {
     this.team = "default";
     this.source = "default";
     this.others = new HashMap<>();
+    this.order = new ArrayList<>();
     this.projects = new ArrayList<>();
   }
 
@@ -55,7 +57,7 @@ public class Topology {
     sb.append(getTeam())
         .append(".")
         .append(getSource());
-    for(String key : others.keySet()) {
+    for(String key : order) {
       String value = others.get(key);
       sb.append(".");
       sb.append(value);
@@ -63,9 +65,8 @@ public class Topology {
     return sb.toString();
   }
 
-  public void addDynamicAttrs(Map<String, String> others) {
-    for(String key : others.keySet()) {
-      this.others.put(key, others.get(key));
-    }
+  public void addOther(String fieldName, String value) {
+    order.add(fieldName);
+    others.put(fieldName, value);
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/model/Topology.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Topology.java
@@ -1,18 +1,23 @@
 package com.purbon.kafka.topology.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Topology {
 
   private String team;
   private String source;
 
+  private Map<String, String> others;
+
   private List<Project> projects;
 
   public Topology() {
     this.team = "default";
     this.source = "default";
+    this.others = new HashMap<>();
     this.projects = new ArrayList<>();
   }
 
@@ -50,6 +55,17 @@ public class Topology {
     sb.append(getTeam())
         .append(".")
         .append(getSource());
+    for(String key : others.keySet()) {
+      String value = others.get(key);
+      sb.append(".");
+      sb.append(value);
+    }
     return sb.toString();
+  }
+
+  public void addDynamicAttrs(Map<String, String> others) {
+    for(String key : others.keySet()) {
+      this.others.put(key, others.get(key));
+    }
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -8,24 +8,40 @@ import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.KStream;
 import com.purbon.kafka.topology.model.users.Producer;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import javax.sound.midi.SysexMessage;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TopologySerdesTest {
 
-
   private TopologySerdes parser;
 
   @Before
   public void setup() {
     parser = new TopologySerdes();
+  }
+
+  @Test
+  public void testDynamicFirstLevelAttributes() throws IOException, URISyntaxException {
+
+    URL descriptorWithOptionals = getClass().getResource("/descriptor-with-others.yml");
+
+    Topology topology = parser.deserialise(Paths.get(descriptorWithOptionals.toURI()).toFile());
+    Assert.assertEquals("team.source.foo.bar.zet", topology.buildNamePrefix());
+
+    URL descriptorWithoutOptionals = getClass().getResource("/descriptor.yaml");
+
+    Topology anotherTopology = parser.deserialise(Paths.get(descriptorWithoutOptionals.toURI()).toFile());
+    Assert.assertEquals("team.source", anotherTopology.buildNamePrefix());
+
   }
 
   @Test

--- a/src/test/resources/descriptor-with-others.yml
+++ b/src/test/resources/descriptor-with-others.yml
@@ -1,0 +1,55 @@
+---
+team: "team"
+source: "source"
+foo: "foo"
+bar: "bar"
+zet: "zet"
+projects:
+  - name: "foo"
+    zookeepers: []
+    consumers:
+      - principal: "User:App0"
+      - principal: "User:App1"
+    producers: []
+    streams:
+      - principal: "User:App0"
+        topics:
+          read:
+            - "topicA"
+            - "topicB"
+          write:
+            - "topicC"
+            - "topicD"
+    connectors:
+      - principal: "User:Connect1"
+        topics:
+          read:
+            - "topicA"
+            - "topicB"
+      - principal: "User:Connect2"
+        topics:
+          write:
+            - "topicC"
+            - "topicD"
+    topics:
+      - name: "foo"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+      - dataType: "avro"
+        name: "bar"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+  - name: "bar"
+    zookeepers: []
+    consumers: []
+    producers: []
+    streams: []
+    connectors: []
+    topics:
+      - dataType: "avro"
+        name: "bar"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"

--- a/src/test/resources/descriptor.yaml
+++ b/src/test/resources/descriptor.yaml
@@ -1,0 +1,52 @@
+---
+team: "team"
+source: "source"
+projects:
+  - name: "foo"
+    zookeepers: []
+    consumers:
+      - principal: "User:App0"
+      - principal: "User:App1"
+    producers: []
+    streams:
+      - principal: "User:App0"
+        topics:
+          read:
+            - "topicA"
+            - "topicB"
+          write:
+            - "topicC"
+            - "topicD"
+    connectors:
+      - principal: "User:Connect1"
+        topics:
+          read:
+            - "topicA"
+            - "topicB"
+      - principal: "User:Connect2"
+        topics:
+          write:
+            - "topicC"
+            - "topicD"
+    topics:
+      - name: "foo"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+      - dataType: "avro"
+        name: "bar"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+  - name: "bar"
+    zookeepers: []
+    consumers: []
+    producers: []
+    streams: []
+    connectors: []
+    topics:
+      - dataType: "avro"
+        name: "bar"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"


### PR DESCRIPTION
This PR adds dynamic attributes as first level. This will enable the possibility for teams to customise their top level descriptors.

With a descriptor like:

```yaml
team: "team"
source: "source"
foo: "foo"
bar: "bar"
zet: "zet"
projects:
  - name: "foo"
```

a prefix will be generated like:

_team.source.foo.bar.zet_

while with a descriptor like:

```yaml
team: "team"
source: "source"
projects:
  - name: "foo"
```
a prefix like _team.source_ will be used.

Fix #8 