### PR TITLE
Add release mechanism for docker images with the kafka topology builder

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos
+MAINTAINER pere.urbon@gmail.com
+ENV container docker
+ENV BUILDER_HOME /usr/local/kafka-topology-builder
+ENV PATH="${BUILDER_HOME}:${PATH}"
+
+USER root
+
+RUN yum install -y java-1.8.0-openjdk
+
+RUN mkdir -p /usr/local/kafka-topology-builder/bin
+COPY kafka-topology-builder-jar-with-dependencies.jar /usr/local/kafka-topology-builder/bin
+COPY kafka-topology-builder.sh /usr/local/kafka-topology-builder
+
+RUN chmod 755 /usr/local/kafka-topology-builder
+
+CMD ["kafka-topology-builder.sh"]

--- a/release/docker/build.sh
+++ b/release/docker/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cp  ../../target/kafka-topology-builder-jar-with-dependencies.jar .
+cp ../../src/main/scripts/kafka-topology-builder.sh .
+
+docker build  -t purbon/kafka-topology-builder .
+
+rm kafka-topology-builder-jar-with-dependencies.jar
+rm kafka-topology-builder.sh


### PR DESCRIPTION
Adds an initial set of scripts and dockerfile for releasing docker images into docker hub. This images are very useful for building CI/CD pipelines or to be used inside kubernetes.