### PR TITLE
Fixes problems with empty fields in the acls principals list

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@ the same team and all subsequent projects will be at append one after the other.
 Note in the future this subsystem should be externalised as plugins
 * raise up error handling in case of non available cluster
 * Make usage of the maven jdeb plugin to build a deb package to use in distributions such as Debian and relative like the Ubuntu family
-
+* Fix parser problem with non required parameters, such as the ones for the acls where an empty array had to be in place, now all principals for acls if not required can be ignored and will have no effect
 
 v0.11:
 * Add support for platform wide acls for schema registry in the topology description file.

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
@@ -272,8 +272,7 @@ public class TopologyBuilderAdminClient {
     Stream.of(AclOperation.WRITE, AclOperation.READ, AclOperation.CREATE, AclOperation.DESCRIBE)
         .map(
             aclOperation ->
-                buildTopicLevelAcl(
-                    principal, appId, PatternType.PREFIXED, aclOperation))
+                buildTopicLevelAcl(principal, appId, PatternType.PREFIXED, aclOperation))
         .forEach(aclBinding -> bindings.add(aclBinding));
 
     ResourcePattern resourcePattern =

--- a/src/main/java/com/purbon/kafka/topology/serdes/ProjectCustomDeserializer.java
+++ b/src/main/java/com/purbon/kafka/topology/serdes/ProjectCustomDeserializer.java
@@ -48,26 +48,35 @@ public class ProjectCustomDeserializer extends StdDeserializer<Project> {
 
     JsonSerdesUtils<Consumer> consumerSerdes = new JsonSerdesUtils<>();
     JsonNode consumers = rootNode.get(CONSUMERS_KEY);
-    List<Consumer> consumersList =
-        consumerSerdes.parseApplicationUser(parser, consumers, Consumer.class);
-    project.setConsumers(consumersList);
+    if (consumers != null) {
+      List<Consumer> consumersList =
+          consumerSerdes.parseApplicationUser(parser, consumers, Consumer.class);
+      project.setConsumers(consumersList);
+    }
 
     JsonSerdesUtils<Producer> producerSerdes = new JsonSerdesUtils<>();
     JsonNode producers = rootNode.get(PRODUCERS_KEY);
-    List<Producer> producersList =
-        producerSerdes.parseApplicationUser(parser, producers, Producer.class);
-    project.setProducers(producersList);
+    if (producers != null) {
+      List<Producer> producersList =
+          producerSerdes.parseApplicationUser(parser, producers, Producer.class);
+      project.setProducers(producersList);
+    }
 
     JsonSerdesUtils<Connector> connectorSerdes = new JsonSerdesUtils<>();
     JsonNode connectors = rootNode.get(CONNECTORS_KEY);
-    List<Connector> connectorList =
-        connectorSerdes.parseApplicationUser(parser, connectors, Connector.class);
-    project.setConnectors(connectorList);
+    if (connectors != null) {
+      List<Connector> connectorList =
+          connectorSerdes.parseApplicationUser(parser, connectors, Connector.class);
+      project.setConnectors(connectorList);
+    }
 
     JsonSerdesUtils<KStream> streamsSerdes = new JsonSerdesUtils<>();
     JsonNode streams = rootNode.get(STREAMS_KEY);
-    List<KStream> streamsList = streamsSerdes.parseApplicationUser(parser, streams, KStream.class);
-    project.setStreams(streamsList);
+    if (streams != null) {
+      List<KStream> streamsList =
+          streamsSerdes.parseApplicationUser(parser, streams, KStream.class);
+      project.setStreams(streamsList);
+    }
 
     // Parser optional RBAC object, only there if using RBAC provider
     JsonNode rbacRootNode = rootNode.get(RBAC_KEY);

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -1,6 +1,7 @@
 package com.purbon.kafka.topology;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
@@ -179,6 +180,18 @@ public class TopologySerdesTest {
     assertEquals(1, listOfC3.size());
     assertEquals("User:ControlCenter", listOfC3.get(0).getPrincipal());
     assertEquals("controlcenter", listOfC3.get(0).getAppId());
+  }
+
+  @Test
+  public void testOnlyTopics() throws URISyntaxException, IOException {
+
+    URL topologyDescriptor = getClass().getResource("/descriptor-only-topics.yaml");
+    Topology topology = parser.deserialise(Paths.get(topologyDescriptor.toURI()).toFile());
+
+    assertTrue(topology.getProjects().get(0).getConnectors().isEmpty());
+    assertTrue(topology.getProjects().get(0).getProducers().isEmpty());
+    assertTrue(topology.getProjects().get(0).getStreams().isEmpty());
+    assertTrue(topology.getProjects().get(0).getZookeepers().isEmpty());
   }
 
   private List<Project> buildProjects() {

--- a/src/test/resources/descriptor-only-topics.yaml
+++ b/src/test/resources/descriptor-only-topics.yaml
@@ -14,11 +14,6 @@ projects:
           replication.factor: "1"
           num.partitions: "1"
   - name: "bar"
-    zookeepers: []
-    consumers: []
-    producers: []
-    streams: []
-    connectors: []
     topics:
       - dataType: "avro"
         name: "bar"

--- a/src/test/resources/descriptor-only-topics.yaml
+++ b/src/test/resources/descriptor-only-topics.yaml
@@ -1,0 +1,27 @@
+---
+team: "team"
+source: "source"
+projects:
+  - name: "foo"
+    topics:
+      - name: "foo"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+      - dataType: "avro"
+        name: "bar"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"
+  - name: "bar"
+    zookeepers: []
+    consumers: []
+    producers: []
+    streams: []
+    connectors: []
+    topics:
+      - dataType: "avro"
+        name: "bar"
+        config:
+          replication.factor: "1"
+          num.partitions: "1"


### PR DESCRIPTION
Fix parser problem with non required parameters, such as the ones for the acls where an empty array had to be in place, now all principals for acls if not required can be ignored and will have no effect.

fixes #35 