### PR TITLE
Validate required parameters for the RBAC configuration 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+v1.0.0-rc2:
+* Check for required configuration values for the configuration of RBAC, if not present it raises a Configuration error
+
 v1.0.0-rc1:
 * Add support for platform wide acls for control center in teh topology description file.
 * Port support for schema registry and confluent control center roles in the rbac provider. Now the two providers are future pair.

--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -4,11 +4,13 @@ import static com.purbon.kafka.topology.BuilderCLI.ALLOW_DELETE_OPTION;
 
 import com.purbon.kafka.topology.model.DynamicUser;
 import com.purbon.kafka.topology.model.Platform;
+import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.model.User;
 import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.KStream;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -65,49 +67,40 @@ public class AccessControlManager {
     }
   }
 
-  public void sync(final Topology topology) {
+  public void sync(final Topology topology) throws IOException {
 
     clearAcls();
 
-    topology
-        .getProjects()
-        .forEach(
-            project -> {
-              project
-                  .getTopics()
-                  .forEach(
-                      topic -> {
-                        final String fullTopicName = topic.toString();
+    for (Project project : topology.getProjects()) {
+      project
+          .getTopics()
+          .forEach(
+              topic -> {
+                final String fullTopicName = topic.toString();
 
-                        Collection<String> consumerPrincipals =
-                            extractUsersToPrincipals(project.getConsumers());
+                Collection<String> consumerPrincipals =
+                    extractUsersToPrincipals(project.getConsumers());
 
-                        List<TopologyAclBinding> consumerBindings =
-                            controlProvider.setAclsForConsumers(consumerPrincipals, fullTopicName);
-                        clusterState.update(consumerBindings);
+                List<TopologyAclBinding> consumerBindings =
+                    controlProvider.setAclsForConsumers(consumerPrincipals, fullTopicName);
+                clusterState.update(consumerBindings);
 
-                        Collection<String> producerPrincipals =
-                            extractUsersToPrincipals(project.getProducers());
-                        List<TopologyAclBinding> producerBindings =
-                            controlProvider.setAclsForProducers(producerPrincipals, fullTopicName);
-                        clusterState.update(producerBindings);
-                      });
-              // Setup global Kafka Stream Access control lists
-              String topicPrefix = project.buildTopicPrefix(topology);
-              project
-                  .getStreams()
-                  .forEach(
-                      app -> {
-                        syncApplicationAcls(app, topicPrefix);
-                      });
-              project
-                  .getConnectors()
-                  .forEach(
-                      connector -> {
-                        syncApplicationAcls(connector, topicPrefix);
-                      });
-              syncRbacRawRoles(project.getRbacRawRoles(), topicPrefix);
-            });
+                Collection<String> producerPrincipals =
+                    extractUsersToPrincipals(project.getProducers());
+                List<TopologyAclBinding> producerBindings =
+                    controlProvider.setAclsForProducers(producerPrincipals, fullTopicName);
+                clusterState.update(producerBindings);
+              });
+      // Setup global Kafka Stream Access control lists
+      String topicPrefix = project.buildTopicPrefix(topology);
+      for (KStream app : project.getStreams()) {
+        syncApplicationAcls(app, topicPrefix);
+      }
+      for (Connector connector : project.getConnectors()) {
+        syncApplicationAcls(connector, topicPrefix);
+      }
+      syncRbacRawRoles(project.getRbacRawRoles(), topicPrefix);
+    }
 
     syncPlatformAcls(topology);
     clusterState.flushAndClose();
@@ -144,7 +137,7 @@ public class AccessControlManager {
                     controlProvider.setPredefinedRole(principal, predefinedRole, topicPrefix)));
   }
 
-  private void syncApplicationAcls(DynamicUser app, String topicPrefix) {
+  private void syncApplicationAcls(DynamicUser app, String topicPrefix) throws IOException {
     List<String> readTopics = app.getTopics().get(KStream.READ_TOPICS);
     List<String> writeTopics = app.getTopics().get(KStream.WRITE_TOPICS);
     List<TopologyAclBinding> bindings = new ArrayList<>();

--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -2,6 +2,7 @@ package com.purbon.kafka.topology;
 
 import static com.purbon.kafka.topology.BuilderCLI.ALLOW_DELETE_OPTION;
 
+import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.model.DynamicUser;
 import com.purbon.kafka.topology.model.Platform;
 import com.purbon.kafka.topology.model.Project;
@@ -9,6 +10,7 @@ import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.model.User;
 import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.KStream;
+import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -106,17 +108,14 @@ public class AccessControlManager {
     clusterState.flushAndClose();
   }
 
-  private void syncPlatformAcls(final Topology topology) {
+  private void syncPlatformAcls(final Topology topology) throws ConfigurationException {
     // Sync platform relevant Access Control List.
     Platform platform = topology.getPlatform();
-    platform
-        .getSchemaRegistry()
-        .forEach(
-            schemaRegistry -> {
-              List<TopologyAclBinding> bindings =
-                  controlProvider.setAclsForSchemaRegistry(schemaRegistry.getPrincipal());
-              clusterState.update(bindings);
-            });
+    for (SchemaRegistry schemaRegistry : platform.getSchemaRegistry()) {
+      List<TopologyAclBinding> bindings =
+          controlProvider.setAclsForSchemaRegistry(schemaRegistry.getPrincipal());
+      clusterState.update(bindings);
+    }
 
     platform
         .getControlCenter()

--- a/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
@@ -1,6 +1,7 @@
 package com.purbon.kafka.topology;
 
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -10,7 +11,8 @@ public interface AccessControlProvider {
   void clearAcls(ClusterState clusterState);
 
   List<TopologyAclBinding> setAclsForConnect(
-      String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics);
+      String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics)
+      throws IOException;
 
   List<TopologyAclBinding> setAclsForStreamsApp(
       String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics);

--- a/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
@@ -1,5 +1,6 @@
 package com.purbon.kafka.topology;
 
+import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.util.Collection;
@@ -29,7 +30,7 @@ public interface AccessControlProvider {
 
   Map<String, List<TopologyAclBinding>> listAcls();
 
-  List<TopologyAclBinding> setAclsForSchemaRegistry(String principal);
+  List<TopologyAclBinding> setAclsForSchemaRegistry(String principal) throws ConfigurationException;
 
   List<TopologyAclBinding> setAclsForControlCenter(String principal, String appId);
 }

--- a/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
@@ -75,19 +75,23 @@ public class KafkaTopologyBuilder {
 
   public void run() throws IOException {
 
-    Topology topology = buildTopology(topologyFile);
-    AccessControlProvider aclsProvider = buildAccessControlProvider();
-    ClusterState cs = buildStateProcessor();
+    try {
+      Topology topology = buildTopology(topologyFile);
+      AccessControlProvider aclsProvider = buildAccessControlProvider();
+      ClusterState cs = buildStateProcessor();
 
-    AccessControlManager accessControlManager =
-        new AccessControlManager(aclsProvider, cs, cliParams);
+      AccessControlManager accessControlManager =
+          new AccessControlManager(aclsProvider, cs, cliParams);
 
-    TopicManager topicManager = new TopicManager(builderAdminClient, cliParams);
-    topicManager.sync(topology);
-    accessControlManager.sync(topology);
-    if (!quiteOut) {
-      topicManager.printCurrentState(System.out);
-      accessControlManager.printCurrentState(System.out);
+      TopicManager topicManager = new TopicManager(builderAdminClient, cliParams);
+      topicManager.sync(topology);
+      accessControlManager.sync(topology);
+      if (!quiteOut) {
+        topicManager.printCurrentState(System.out);
+        accessControlManager.printCurrentState(System.out);
+      }
+    } finally {
+      builderAdminClient.close();
     }
   }
 

--- a/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
@@ -21,8 +21,6 @@ import static com.purbon.kafka.topology.TopologyBuilderConfig.STATE_PROCESSOR_IM
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.clusterstate.FileSateProcessor;
 import com.purbon.kafka.topology.clusterstate.RedisSateProcessor;
-import com.purbon.kafka.topology.exceptions.ConfigurationException;
-import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.roles.RBACProvider;
 import com.purbon.kafka.topology.roles.SimpleAclsProvider;
@@ -45,32 +43,28 @@ public class KafkaTopologyBuilder {
 
   private final String topologyFile;
   private final TopologySerdes parser;
-  private final Properties properties;
   private final TopologyBuilderAdminClient builderAdminClient;
   private final boolean quiteOut;
-  private final Map<String, String> cliParams;
+  private final TopologyBuilderConfig config;
 
   public KafkaTopologyBuilder(String topologyFile, Map<String, String> cliParams) {
     this(
         topologyFile,
-        cliParams,
         new TopologySerdes(),
-        buildProperties(cliParams),
+        new TopologyBuilderConfig(cliParams, buildProperties(cliParams)),
         buildTopologyAdminClient(cliParams),
         Boolean.valueOf(cliParams.getOrDefault(QUITE_OPTION, "false")));
   }
 
   public KafkaTopologyBuilder(
       String topologyFile,
-      Map<String, String> cliParams,
       TopologySerdes parser,
-      Properties properties,
+      TopologyBuilderConfig config,
       TopologyBuilderAdminClient adminClient,
       boolean quiteOut) {
     this.topologyFile = topologyFile;
     this.parser = parser;
-    this.cliParams = cliParams;
-    this.properties = properties;
+    this.config = config;
     this.builderAdminClient = adminClient;
     this.quiteOut = quiteOut;
   }
@@ -79,15 +73,15 @@ public class KafkaTopologyBuilder {
 
     try {
       Topology topology = buildTopology(topologyFile);
-      validateConfiguration(topology, properties);
+      config.validateWith(topology);
 
       AccessControlProvider aclsProvider = buildAccessControlProvider();
       ClusterState cs = buildStateProcessor();
 
       AccessControlManager accessControlManager =
-          new AccessControlManager(aclsProvider, cs, cliParams);
+          new AccessControlManager(aclsProvider, cs, config.params());
 
-      TopicManager topicManager = new TopicManager(builderAdminClient, cliParams);
+      TopicManager topicManager = new TopicManager(builderAdminClient, config.params());
       topicManager.sync(topology);
       accessControlManager.sync(topology);
       if (!quiteOut) {
@@ -154,7 +148,7 @@ public class KafkaTopologyBuilder {
   private ClusterState buildStateProcessor() throws IOException {
 
     String stateProcessorClass =
-        properties
+        config
             .getOrDefault(STATE_PROCESSOR_IMPLEMENTATION_CLASS, STATE_PROCESSOR_DEFAULT_CLASS)
             .toString();
 
@@ -162,8 +156,8 @@ public class KafkaTopologyBuilder {
       if (stateProcessorClass.equalsIgnoreCase(STATE_PROCESSOR_DEFAULT_CLASS)) {
         return new ClusterState(new FileSateProcessor());
       } else if (stateProcessorClass.equalsIgnoreCase(REDIS_STATE_PROCESSOR_CLASS)) {
-        String host = properties.getProperty(REDIS_HOST_CONFIG);
-        int port = Integer.valueOf(properties.getProperty(REDIS_PORT_CONFIG));
+        String host = config.getProperty(REDIS_HOST_CONFIG);
+        int port = Integer.valueOf(config.getProperty(REDIS_PORT_CONFIG));
         return new ClusterState(new RedisSateProcessor(host, port));
       } else {
         throw new IOException(stateProcessorClass + " Unknown state processor provided.");
@@ -175,7 +169,7 @@ public class KafkaTopologyBuilder {
 
   public AccessControlProvider buildAccessControlProvider() throws IOException {
     String accessControlClass =
-        properties
+        config
             .getOrDefault(
                 ACCESS_CONTROL_IMPLEMENTATION_CLASS,
                 "com.purbon.kafka.topology.roles.SimpleAclsProvider")
@@ -189,18 +183,18 @@ public class KafkaTopologyBuilder {
         return (SimpleAclsProvider) constructor.newInstance(builderAdminClient);
       } else if (accessControlClass.equalsIgnoreCase(RBAC_ACCESS_CONTROL_CLASS)) {
 
-        String mdsServer = properties.getProperty(MDS_SERVER);
-        String mdsUser = properties.getProperty(MDS_USER_CONFIG);
-        String mdsPassword = properties.getProperty(MDS_PASSWORD_CONFIG);
+        String mdsServer = config.getProperty(MDS_SERVER);
+        String mdsUser = config.getProperty(MDS_USER_CONFIG);
+        String mdsPassword = config.getProperty(MDS_PASSWORD_CONFIG);
 
         MDSApiClient apiClient = new MDSApiClient(mdsServer);
 
         // Pass Cluster IDS
-        String kafkaClusterID = properties.getProperty(MDS_KAFKA_CLUSTER_ID_CONFIG);
+        String kafkaClusterID = config.getProperty(MDS_KAFKA_CLUSTER_ID_CONFIG);
         apiClient.setKafkaClusterId(kafkaClusterID);
-        String schemaRegistryClusterID = properties.getProperty(MDS_SR_CLUSTER_ID_CONFIG);
+        String schemaRegistryClusterID = config.getProperty(MDS_SR_CLUSTER_ID_CONFIG);
         apiClient.setSchemaRegistryClusterID(schemaRegistryClusterID);
-        String kafkaConnectClusterID = properties.getProperty(MDS_KC_CLUSTER_ID_CONFIG);
+        String kafkaConnectClusterID = config.getProperty(MDS_KC_CLUSTER_ID_CONFIG);
         apiClient.setConnectClusterID(kafkaConnectClusterID);
 
         // Login and authenticate with the server
@@ -243,44 +237,5 @@ public class KafkaTopologyBuilder {
     // props.put("default.api.timeout.ms", 10000);
     // props.put("request.timeout.ms", 10000);
     return AdminClient.create(props);
-  }
-
-  private void validateConfiguration(Topology topology, Properties properties)
-      throws ConfigurationException {
-
-    boolean isRbac =
-        properties
-            .getProperty(ACCESS_CONTROL_IMPLEMENTATION_CLASS)
-            .equalsIgnoreCase(RBAC_ACCESS_CONTROL_CLASS);
-    if (!isRbac) {
-      return;
-    }
-
-    raiseIfNull(MDS_SERVER, properties.getProperty(MDS_SERVER));
-    raiseIfNull(MDS_USER_CONFIG, properties.getProperty(MDS_USER_CONFIG));
-    raiseIfNull(MDS_PASSWORD_CONFIG, properties.getProperty(MDS_PASSWORD_CONFIG));
-
-    boolean hasSchemaRegistry = !topology.getPlatform().getSchemaRegistry().isEmpty();
-    boolean hasKafkaConnect = false;
-    List<Project> projects = topology.getProjects();
-    for (int i = 0; !hasKafkaConnect && i < projects.size(); i++) {
-      Project project = projects.get(i);
-      hasKafkaConnect = !project.getConnectors().isEmpty();
-    }
-
-    raiseIfNull(MDS_KAFKA_CLUSTER_ID_CONFIG, properties.getProperty(MDS_KAFKA_CLUSTER_ID_CONFIG));
-
-    if (hasSchemaRegistry) {
-      raiseIfNull(MDS_SR_CLUSTER_ID_CONFIG, properties.getProperty(MDS_SR_CLUSTER_ID_CONFIG));
-    } else if (hasKafkaConnect && properties.getProperty(MDS_KC_CLUSTER_ID_CONFIG) == null) {
-      raiseIfNull(MDS_KC_CLUSTER_ID_CONFIG, properties.getProperty(MDS_KC_CLUSTER_ID_CONFIG));
-    }
-  }
-
-  private void raiseIfNull(String key, String value) throws ConfigurationException {
-    if (value == null) {
-      throw new ConfigurationException(
-          "Required configuration " + key + " is missing, please add it to your configuration");
-    }
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
@@ -374,4 +374,8 @@ public class TopologyBuilderAdminClient {
         .addControlEntry("*", op, AclPermissionType.ALLOW)
         .build();
   }
+
+  public void close() {
+    adminClient.close();
+  }
 }

--- a/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
+++ b/src/main/java/com/purbon/kafka/topology/api/mds/MDSApiClient.java
@@ -198,17 +198,17 @@ public class MDSApiClient {
 
   public Map<String, Map<String, String>> getClusterIds() {
     HashMap<String, String> clusterIds = new HashMap<>();
-    if (!kafkaClusterID.isEmpty()) clusterIds.put(KAFKA_CLUSTER_ID_LABEL, kafkaClusterID);
-    if (!schemaRegistryClusterID.isEmpty())
-      clusterIds.put(SCHEMA_REGISTRY_CLUSTER_ID_LABEL, schemaRegistryClusterID);
-    if (!connectClusterID.isEmpty()) clusterIds.put(CONNECT_CLUSTER_ID_LABEL, connectClusterID);
-
-    // clusterIds.put("connect-cluster", "connect-cluster");
-    // clusterIds.put("ksql-cluster", "ksqlCluster");
+    setClusterID(clusterIds, KAFKA_CLUSTER_ID_LABEL, kafkaClusterID);
+    setClusterID(clusterIds, SCHEMA_REGISTRY_CLUSTER_ID_LABEL, schemaRegistryClusterID);
+    setClusterID(clusterIds, CONNECT_CLUSTER_ID_LABEL, connectClusterID);
 
     Map<String, Map<String, String>> clusters = new HashMap<>();
     clusters.put("clusters", clusterIds);
     return clusters;
+  }
+
+  private void setClusterID(Map<String, String> clusterIds, String label, String value) {
+    if (value != null && !value.isEmpty()) clusterIds.put(label, value);
   }
 
   private final CloseableHttpClient httpClient = HttpClients.createDefault();

--- a/src/main/java/com/purbon/kafka/topology/exceptions/ConfigurationException.java
+++ b/src/main/java/com/purbon/kafka/topology/exceptions/ConfigurationException.java
@@ -1,0 +1,10 @@
+package com.purbon.kafka.topology.exceptions;
+
+import java.io.IOException;
+
+public class ConfigurationException extends IOException {
+
+  public ConfigurationException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/roles/AdminRoleRunner.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/AdminRoleRunner.java
@@ -26,9 +26,11 @@ public class AdminRoleRunner {
     this.resourceName = "";
   }
 
-  public AdminRoleRunner forSchemaRegistry() {
+  public AdminRoleRunner forSchemaRegistry() throws ConfigurationException {
     Map<String, String> clusterIds = new HashMap<>();
     Map<String, String> allClusterIds = client.getClusterIds().get("clusters");
+    validateRequiredClusterLabels(
+        allClusterIds, KAFKA_CLUSTER_ID_LABEL, SCHEMA_REGISTRY_CLUSTER_ID_LABEL);
     clusterIds.put(KAFKA_CLUSTER_ID_LABEL, allClusterIds.get(KAFKA_CLUSTER_ID_LABEL));
     clusterIds.put(
         SCHEMA_REGISTRY_CLUSTER_ID_LABEL, allClusterIds.get(SCHEMA_REGISTRY_CLUSTER_ID_LABEL));

--- a/src/main/java/com/purbon/kafka/topology/roles/AdminRoleRunner.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/AdminRoleRunner.java
@@ -5,6 +5,8 @@ import static com.purbon.kafka.topology.api.mds.MDSApiClient.KAFKA_CLUSTER_ID_LA
 import static com.purbon.kafka.topology.api.mds.MDSApiClient.SCHEMA_REGISTRY_CLUSTER_ID_LABEL;
 
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
+import com.purbon.kafka.topology.exceptions.ConfigurationException;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,9 +51,10 @@ public class AdminRoleRunner {
     return this;
   }
 
-  public AdminRoleRunner forKafkaConnect() {
+  public AdminRoleRunner forKafkaConnect() throws IOException {
     Map<String, String> clusterIds = new HashMap<>();
     Map<String, String> allClusterIds = client.getClusterIds().get("clusters");
+    validateRequiredClusterLabels(allClusterIds, KAFKA_CLUSTER_ID_LABEL, CONNECT_CLUSTER_ID_LABEL);
     clusterIds.put(KAFKA_CLUSTER_ID_LABEL, allClusterIds.get(KAFKA_CLUSTER_ID_LABEL));
     clusterIds.put(CONNECT_CLUSTER_ID_LABEL, allClusterIds.get(CONNECT_CLUSTER_ID_LABEL));
 
@@ -60,5 +63,23 @@ public class AdminRoleRunner {
 
     this.resourceName = "kafka-connect";
     return this;
+  }
+
+  public Map<String, Object> getScope() {
+    return scope;
+  }
+
+  public String getResourceName() {
+    return resourceName;
+  }
+
+  private void validateRequiredClusterLabels(
+      Map<String, String> allClusterIds, String... clusterLabels) throws ConfigurationException {
+    for (String label : clusterLabels) {
+      if (allClusterIds.get(label) == null) {
+        throw new ConfigurationException(
+            "Required clusterID " + label + " is missing, please add it to your configuration");
+      }
+    }
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
@@ -10,6 +10,7 @@ import com.purbon.kafka.topology.AccessControlProvider;
 import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.api.mds.RequestScope;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,7 +54,8 @@ public class RBACProvider implements AccessControlProvider {
 
   @Override
   public List<TopologyAclBinding> setAclsForConnect(
-      String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics) {
+      String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics)
+      throws IOException {
 
     List<TopologyAclBinding> bindings = new ArrayList<>();
 

--- a/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
@@ -187,7 +187,7 @@ public class RBACProvider implements AccessControlProvider {
 
   @Override
   public Map<String, List<TopologyAclBinding>> listAcls() {
-    LOGGER.warn("Not implemented yet!");
+    LOGGER.info("Not implemented yet!");
     return new HashMap<>();
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
@@ -10,6 +10,7 @@ import com.purbon.kafka.topology.AccessControlProvider;
 import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.api.mds.RequestScope;
+import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -165,7 +166,8 @@ public class RBACProvider implements AccessControlProvider {
   }
 
   @Override
-  public List<TopologyAclBinding> setAclsForSchemaRegistry(String principal) {
+  public List<TopologyAclBinding> setAclsForSchemaRegistry(String principal)
+      throws ConfigurationException {
     List<TopologyAclBinding> bindings = new ArrayList<>();
     TopologyAclBinding binding =
         apiClient.bind(principal, SECURITY_ADMIN).forSchemaRegistry().apply();

--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -18,6 +18,7 @@ import com.purbon.kafka.topology.model.users.Producer;
 import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import com.purbon.kafka.topology.roles.SimpleAclsProvider;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,7 +50,7 @@ public class AccessControlManagerTest {
   }
 
   @Test
-  public void newConsumerACLsCreation() {
+  public void newConsumerACLsCreation() throws IOException {
 
     List<Consumer> consumers = new ArrayList<>();
     consumers.add(new Consumer("User:app1"));
@@ -72,7 +73,7 @@ public class AccessControlManagerTest {
   }
 
   @Test
-  public void newProducerACLsCreation() {
+  public void newProducerACLsCreation() throws IOException {
 
     List<Producer> producers = new ArrayList<>();
     producers.add(new Producer("User:app1"));
@@ -95,7 +96,7 @@ public class AccessControlManagerTest {
   }
 
   @Test
-  public void newKafkaStreamsAppACLsCreation() {
+  public void newKafkaStreamsAppACLsCreation() throws IOException {
 
     Project project = new Project();
 
@@ -129,7 +130,7 @@ public class AccessControlManagerTest {
   }
 
   @Test
-  public void newSchemaRegistryACLCreation() {
+  public void newSchemaRegistryACLCreation() throws IOException {
 
     Project project = new Project();
     Topology topology = new Topology();
@@ -151,7 +152,7 @@ public class AccessControlManagerTest {
   }
 
   @Test
-  public void newControlCenterACLCreation() {
+  public void newControlCenterACLCreation() throws IOException {
 
     Project project = new Project();
     Topology topology = new Topology();
@@ -174,7 +175,7 @@ public class AccessControlManagerTest {
   }
 
   @Test
-  public void newKafkaConnectACLsCreation() {
+  public void newKafkaConnectACLsCreation() throws IOException {
 
     Project project = new Project();
 

--- a/src/test/java/com/purbon/kafka/topology/AccessControlWithRBACTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlWithRBACTest.java
@@ -9,6 +9,7 @@ import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.roles.RBACProvider;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -34,7 +35,7 @@ public class AccessControlWithRBACTest {
   }
 
   @Test
-  public void testPredefinedRoles() {
+  public void testPredefinedRoles() throws IOException {
 
     Map<String, List<String>> predefinedRoles = new HashMap<>();
     predefinedRoles.put("ResourceOwner", Arrays.asList("User:Foo"));

--- a/src/test/java/com/purbon/kafka/topology/AdminRoleRunnerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AdminRoleRunnerTest.java
@@ -66,4 +66,28 @@ public class AdminRoleRunnerTest {
     AdminRoleRunner runner = new AdminRoleRunner("foo", SECURITY_ADMIN, apiClient);
     runner.forKafkaConnect();
   }
+
+  @Test
+  public void testWithAllClientIdsForSchemaRegistry() throws IOException {
+
+    when(apiClient.getClusterIds()).thenReturn(allClusterIds);
+
+    AdminRoleRunner runner = new AdminRoleRunner("foo", SECURITY_ADMIN, apiClient);
+    runner.forSchemaRegistry();
+
+    assertEquals("schema-registry", runner.getResourceName());
+
+    String connectClusterId = "4321";
+    Map<String, String> clusterIDs = (Map<String, String>) runner.getScope().get("clusters");
+    assertEquals(connectClusterId, clusterIDs.get(SCHEMA_REGISTRY_CLUSTER_ID_LABEL));
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void testWithMissingClientIdsForSchemaRegistry() throws IOException {
+
+    when(apiClient.getClusterIds()).thenReturn(noClusterIds);
+
+    AdminRoleRunner runner = new AdminRoleRunner("foo", SECURITY_ADMIN, apiClient);
+    runner.forSchemaRegistry();
+  }
 }

--- a/src/test/java/com/purbon/kafka/topology/AdminRoleRunnerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AdminRoleRunnerTest.java
@@ -1,0 +1,69 @@
+package com.purbon.kafka.topology;
+
+import static com.purbon.kafka.topology.api.mds.MDSApiClient.CONNECT_CLUSTER_ID_LABEL;
+import static com.purbon.kafka.topology.api.mds.MDSApiClient.KAFKA_CLUSTER_ID_LABEL;
+import static com.purbon.kafka.topology.api.mds.MDSApiClient.SCHEMA_REGISTRY_CLUSTER_ID_LABEL;
+import static com.purbon.kafka.topology.roles.RBACPredefinedRoles.SECURITY_ADMIN;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.purbon.kafka.topology.api.mds.MDSApiClient;
+import com.purbon.kafka.topology.exceptions.ConfigurationException;
+import com.purbon.kafka.topology.roles.AdminRoleRunner;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class AdminRoleRunnerTest {
+
+  @Mock MDSApiClient apiClient;
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private static Map<String, Map<String, String>> allClusterIds;
+  private static Map<String, Map<String, String>> noClusterIds;
+
+  @BeforeClass
+  public static void before() {
+
+    Map<String, String> allIds = new HashMap<>();
+
+    allIds.put(CONNECT_CLUSTER_ID_LABEL, "1234");
+    allIds.put(SCHEMA_REGISTRY_CLUSTER_ID_LABEL, "4321");
+    allIds.put(KAFKA_CLUSTER_ID_LABEL, "abcd");
+
+    allClusterIds = Collections.singletonMap("clusters", allIds);
+    noClusterIds = Collections.singletonMap("clusters", new HashMap<>());
+  }
+
+  @Test
+  public void testWithAllClientIdsForConnect() throws IOException {
+
+    when(apiClient.getClusterIds()).thenReturn(allClusterIds);
+
+    AdminRoleRunner runner = new AdminRoleRunner("foo", SECURITY_ADMIN, apiClient);
+    runner.forKafkaConnect();
+
+    assertEquals("kafka-connect", runner.getResourceName());
+
+    String connectClusterId = "1234";
+    Map<String, String> clusterIDs = (Map<String, String>) runner.getScope().get("clusters");
+    assertEquals(connectClusterId, clusterIDs.get(CONNECT_CLUSTER_ID_LABEL));
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void testWithMissingClientIdsForConnect() throws IOException {
+
+    when(apiClient.getClusterIds()).thenReturn(noClusterIds);
+
+    AdminRoleRunner runner = new AdminRoleRunner("foo", SECURITY_ADMIN, apiClient);
+    runner.forKafkaConnect();
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/KafkaTopologyBuilderTest.java
+++ b/src/test/java/com/purbon/kafka/topology/KafkaTopologyBuilderTest.java
@@ -51,7 +51,11 @@ public class KafkaTopologyBuilderTest {
 
     KafkaTopologyBuilder builder =
         new KafkaTopologyBuilder(
-            fileOrDirPath, cliOps, new TopologySerdes(), props, topologyAdminClient, false);
+            fileOrDirPath,
+            new TopologySerdes(),
+            new TopologyBuilderConfig(cliOps, props),
+            topologyAdminClient,
+            false);
 
     Topology topology = builder.buildTopology(fileOrDirPath);
 
@@ -71,7 +75,11 @@ public class KafkaTopologyBuilderTest {
 
     KafkaTopologyBuilder builder =
         new KafkaTopologyBuilder(
-            fileOrDirPath, cliOps, new TopologySerdes(), props, topologyAdminClient, false);
+            fileOrDirPath,
+            new TopologySerdes(),
+            new TopologyBuilderConfig(cliOps, props),
+            topologyAdminClient,
+            false);
 
     builder.buildAccessControlProvider();
   }

--- a/src/test/java/com/purbon/kafka/topology/TopologyBuilderConfigTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyBuilderConfigTest.java
@@ -1,0 +1,50 @@
+package com.purbon.kafka.topology;
+
+import static com.purbon.kafka.topology.BuilderCLI.BROKERS_OPTION;
+import static com.purbon.kafka.topology.TopologyBuilderConfig.ACCESS_CONTROL_IMPLEMENTATION_CLASS;
+import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_KAFKA_CLUSTER_ID_CONFIG;
+import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_PASSWORD_CONFIG;
+import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_SERVER;
+import static com.purbon.kafka.topology.TopologyBuilderConfig.MDS_USER_CONFIG;
+
+import com.purbon.kafka.topology.exceptions.ConfigurationException;
+import com.purbon.kafka.topology.model.Topology;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TopologyBuilderConfigTest {
+
+  Map<String, String> cliOps;
+  Properties props;
+
+  @Before
+  public void before() {
+    cliOps = new HashMap<>();
+    cliOps.put(BROKERS_OPTION, "");
+    props = new Properties();
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void testRequiredAccessControlClassFields() throws ConfigurationException {
+    Topology topology = new Topology();
+    TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
+    config.validateWith(topology);
+  }
+
+  @Test
+  public void testWithAllRequiredFields() throws ConfigurationException {
+    Topology topology = new Topology();
+
+    props.put(ACCESS_CONTROL_IMPLEMENTATION_CLASS, TopologyBuilderConfig.RBAC_ACCESS_CONTROL_CLASS);
+    props.put(MDS_SERVER, "example.com");
+    props.put(MDS_USER_CONFIG, "foo");
+    props.put(MDS_PASSWORD_CONFIG, "bar");
+    props.put(MDS_KAFKA_CLUSTER_ID_CONFIG, "1234");
+
+    TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
+    config.validateWith(topology);
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -57,7 +57,7 @@ public class AccessControlManagerIT {
   }
 
   @Test
-  public void testAclsCleanup() throws ExecutionException, InterruptedException {
+  public void testAclsCleanup() throws ExecutionException, InterruptedException, IOException {
 
     // Crate an ACL outside of the control of the state manager.
     aclsProvider.setAclsForProducers(Collections.singleton("User:foo"), "bar");
@@ -90,7 +90,7 @@ public class AccessControlManagerIT {
   }
 
   @Test
-  public void consumerAclsCreation() throws ExecutionException, InterruptedException {
+  public void consumerAclsCreation() throws ExecutionException, InterruptedException, IOException {
 
     List<Consumer> consumers = new ArrayList<>();
     consumers.add(new Consumer("User:app1"));
@@ -111,7 +111,7 @@ public class AccessControlManagerIT {
   }
 
   @Test
-  public void producerAclsCreation() throws ExecutionException, InterruptedException {
+  public void producerAclsCreation() throws ExecutionException, InterruptedException, IOException {
 
     List<Producer> producers = new ArrayList<>();
     producers.add(new Producer("User:Producer1"));
@@ -132,7 +132,7 @@ public class AccessControlManagerIT {
   }
 
   @Test
-  public void kstreamsAclsCreation() throws ExecutionException, InterruptedException {
+  public void kstreamsAclsCreation() throws ExecutionException, InterruptedException, IOException {
     Project project = new Project();
 
     KStream app = new KStream();
@@ -154,7 +154,8 @@ public class AccessControlManagerIT {
   }
 
   @Test
-  public void schemaRegistryAclsCreation() throws ExecutionException, InterruptedException {
+  public void schemaRegistryAclsCreation()
+      throws ExecutionException, InterruptedException, IOException {
     Project project = new Project();
 
     Topology topology = new Topology();
@@ -179,7 +180,8 @@ public class AccessControlManagerIT {
   }
 
   @Test
-  public void controlcenterAclsCreation() throws ExecutionException, InterruptedException {
+  public void controlcenterAclsCreation()
+      throws ExecutionException, InterruptedException, IOException {
     Project project = new Project();
 
     Topology topology = new Topology();
@@ -201,7 +203,7 @@ public class AccessControlManagerIT {
   }
 
   @Test
-  public void connectAclsCreation() throws ExecutionException, InterruptedException {
+  public void connectAclsCreation() throws ExecutionException, InterruptedException, IOException {
     Project project = new Project();
 
     Connector connector = new Connector();

--- a/src/test/java/com/purbon/kafka/topology/integration/RBACPRoviderRbacIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/RBACPRoviderRbacIT.java
@@ -62,7 +62,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
   }
 
   @Test
-  public void consumerAclsCreation() {
+  public void consumerAclsCreation() throws IOException {
 
     List<Consumer> consumers = new ArrayList<>();
     consumers.add(new Consumer("User:app1"));
@@ -85,7 +85,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
   }
 
   @Test
-  public void producerAclsCreation() {
+  public void producerAclsCreation() throws IOException {
 
     List<Producer> producers = new ArrayList<>();
     producers.add(new Producer("User:app2"));
@@ -108,7 +108,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
   }
 
   @Test
-  public void kstreamsAclsCreation() {
+  public void kstreamsAclsCreation() throws IOException {
     Project project = new Project();
 
     KStream app = new KStream();
@@ -131,7 +131,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
   }
 
   @Test
-  public void connectAclsCreation() {
+  public void connectAclsCreation() throws IOException {
     Project project = new Project();
 
     Connector connector = new Connector();
@@ -153,7 +153,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
   }
 
   @Test
-  public void schemaRegistryAclsCreation() {
+  public void schemaRegistryAclsCreation() throws IOException {
     Project project = new Project();
 
     Topology topology = new Topology();
@@ -179,7 +179,7 @@ public class RBACPRoviderRbacIT extends MDSBaseTest {
   }
 
   @Test
-  public void controlcenterAclsCreation() {
+  public void controlcenterAclsCreation() throws IOException {
     Project project = new Project();
 
     Topology topology = new Topology();


### PR DESCRIPTION
This PR adds validation and meaninful errors back for missing RBAC configuration requirements. If you miss one of the required properties, for example the connect cluster ID an error like this will be shown:

```bash
$>  java -jar target/kafka-topology-builder-jar-with-dependencies.jar  --brokers localhost:9094 --clientConfig example/topology-builder-rbac.properties --topology example/descriptor-with-rbac.yaml
log4j:WARN No appenders could be found for logger (org.apache.kafka.clients.admin.AdminClientConfig).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Exception in thread "main" com.purbon.kafka.topology.exceptions.ConfigurationException: Required clusterID topology.builder.mds.kafka.connect.cluster.id is missing, please add it to your configuration
	at com.purbon.kafka.topology.KafkaTopologyBuilder.validateConfiguration(KafkaTopologyBuilder.java:278)
	at com.purbon.kafka.topology.KafkaTopologyBuilder.run(KafkaTopologyBuilder.java:82)
	at com.purbon.kafka.topology.BuilderCLI.processTopology(BuilderCLI.java:154)
	at com.purbon.kafka.topology.BuilderCLI.main(BuilderCLI.java:118)
```

fixes #47 