### PR TITLE
Amend problem with deleting internal topics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 v1.0.0-rc2:
 * Check for required configuration values for the configuration of RBAC, if not present it raises a Configuration error
 * Update Log4j version to 2.13.3 to prevent CVE-2020-9488
+* Add an option to not delete internal topics, including an option configure rules to filter internal topics that can't not be removed config with  _kafka.internal.topic.prefixes_,
+by default this filters all topics starting with underscore. Users can configure more than one filter in the property file.
 
 v1.0.0-rc1:
 * Add support for platform wide acls for control center in teh topology description file.

--- a/docker/sasl/docker-compose.yml
+++ b/docker/sasl/docker-compose.yml
@@ -43,3 +43,33 @@ services:
       KAFKA_OPTS: '-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf'
       KAFKA_LOG4J_LOGGERS: "kafka.authorizer.logger=DEBUG"
 
+  control-center:
+    image: confluentinc/cp-enterprise-control-center:5.3.1
+    container_name: control-center
+    depends_on:
+      - zookeeper
+      - kafka
+    ports:
+      - "9021:9021"
+    environment:
+      CONTROL_CENTER_BOOTSTRAP_SERVERS: "kafka:29093"
+      CONTROL_CENTER_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      CONTROL_CENTER_REPLICATION_FACTOR: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION: 1
+      CONTROL_CENTER_COMMAND_TOPIC_REPLICATION: 1
+      CONTROL_CENTER_METRICS_TOPIC_REPLICATION: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
+      CONTROL_CENTER_METRICS_TOPIC_PARTITIONS: 1
+      CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS: 1
+      CONTROL_CENTER_STREAMS_CACHE_MAX_BYTES_BUFFERING: 100000000
+      CONTROL_CENTER_CONNECT_CLUSTER: "https://connect:8083"
+      CONTROL_CENTER_DEPRECATED_VIEWS_ENABLE: "true"
+      CONTROL_CENTER_STREAMS_CONSUMER_REQUEST_TIMEOUT_MS: "960032"
+      CONTROL_CENTER_STREAMS_SECURITY_PROTOCOL: SASL_PLAINTEXT
+      CONTROL_CENTER_STREAMS_SASL_JAAS_CONFIG: "org.apache.kafka.common.security.plain.PlainLoginModule required \
+        username=\"kafka\" \
+        password=\"kafka\";"
+      CONTROL_CENTER_STREAMS_SASL_MECHANISM: PLAIN
+      CONTROL_CENTER_REST_LISTENERS: "http://0.0.0.0:9021"

--- a/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
@@ -81,7 +81,7 @@ public class KafkaTopologyBuilder {
       AccessControlManager accessControlManager =
           new AccessControlManager(aclsProvider, cs, config.params());
 
-      TopicManager topicManager = new TopicManager(builderAdminClient, config.params());
+      TopicManager topicManager = new TopicManager(builderAdminClient, config);
       topicManager.sync(topology);
       accessControlManager.sync(topology);
       if (!quiteOut) {

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AccessControlEntryFilter;
@@ -46,15 +47,25 @@ public class TopologyBuilderAdminClient {
     this.adminClient = adminClient;
   }
 
-  public Set<String> listTopics() throws IOException {
+  public Set<String> listTopics(ListTopicsOptions options) throws IOException {
     Set<String> listOfTopics;
     try {
-      listOfTopics = adminClient.listTopics().names().get();
+      listOfTopics = adminClient.listTopics(options).names().get();
     } catch (InterruptedException | ExecutionException e) {
       LOGGER.error(e);
       throw new IOException(e);
     }
     return listOfTopics;
+  }
+
+  public Set<String> listTopics() throws IOException {
+    return listTopics(new ListTopicsOptions());
+  }
+
+  public Set<String> listApplicationTopics() throws IOException {
+    ListTopicsOptions options = new ListTopicsOptions();
+    options.listInternal(false);
+    return listTopics(options);
   }
 
   public void updateTopicConfig(Topic topic, String fullTopicName) throws IOException {

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -3,11 +3,16 @@ package com.purbon.kafka.topology;
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topology;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 public class TopologyBuilderConfig {
+
+  public static final String KAFKA_INTERNAL_TOPIC_PREFIXES = "kafka.internal.topic.prefixes";
+  public static final String KAFKA_INTERNAL_TOPIC_PREFIXES_DEFAULT = "_";
 
   public static final String ACCESS_CONTROL_IMPLEMENTATION_CLASS =
       "topology.builder.access.control.class";
@@ -40,6 +45,10 @@ public class TopologyBuilderConfig {
 
   private final Map<String, String> cliParams;
   private final Properties properties;
+
+  public TopologyBuilderConfig() {
+    this(new HashMap<>(), new Properties());
+  }
 
   public TopologyBuilderConfig(Map<String, String> cliParams, Properties properties) {
     this.cliParams = cliParams;
@@ -96,6 +105,11 @@ public class TopologyBuilderConfig {
 
   public String getProperty(String key) {
     return properties.getProperty(key);
+  }
+
+  public List<String> getPropertyAsList(String key, String def, String regexp) {
+    Object val = properties.getOrDefault(key, def);
+    return Arrays.asList(String.valueOf(val).split(regexp));
   }
 
   public Object getOrDefault(Object key, Object _default) {

--- a/src/main/java/com/purbon/kafka/topology/api/mds/Response.java
+++ b/src/main/java/com/purbon/kafka/topology/api/mds/Response.java
@@ -1,0 +1,65 @@
+package com.purbon.kafka.topology.api.mds;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.purbon.kafka.topology.utils.JSON;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Response {
+
+  private static final Logger LOGGER = LogManager.getLogger(Response.class);
+  private static final String STATUS_FIELD = "status";
+
+  private final String response;
+  private final Map<String, Object> map;
+  private final int statusCode;
+  private final Header headers;
+
+  public Response(CloseableHttpResponse httpResponse) {
+    HttpEntity entity = httpResponse.getEntity();
+    this.headers = entity.getContentType();
+    this.statusCode = httpResponse.getStatusLine().getStatusCode();
+    this.response = parseBodyAsString(entity);
+    this.map = responseToJson(response);
+  }
+
+  public Integer getStatus() {
+    return statusCode;
+  }
+
+  public Object getField(String field) {
+    return map.get(field);
+  }
+
+  private Map<String, Object> responseToJson(String response) {
+    try {
+      return JSON.toMap(response);
+    } catch (JsonProcessingException e) {
+      LOGGER.error(e);
+      return new HashMap<>();
+    }
+  }
+
+  private String parseBodyAsString(HttpEntity entity) {
+    String result = "";
+    if (entity != null) {
+      try {
+        result = EntityUtils.toString(entity);
+      } catch (IOException e) {
+        LOGGER.error(e);
+      }
+    }
+    return result;
+  }
+
+  public String getResponseAsString() {
+    return response;
+  }
+}

--- a/src/test/java/com/purbon/kafka/topology/integration/MDSApiClientRbacIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/MDSApiClientRbacIT.java
@@ -36,23 +36,21 @@ public class MDSApiClientRbacIT extends MDSBaseTest {
   }
 
   @Test
-  public void testMDSLogin() {
+  public void testMDSLogin() throws IOException {
     apiClient.login(mdsUser, mdsPassword);
     apiClient.authenticate();
     AuthenticationCredentials credentials = apiClient.getCredentials();
     assertEquals(false, credentials.getAuthToken().isEmpty());
   }
 
-  @Test
-  public void testWithWrongMDSLogin() {
+  @Test(expected = IOException.class)
+  public void testWithWrongMDSLogin() throws IOException {
     apiClient.login("wrong-user", "wrong-password");
     apiClient.authenticate();
-    AuthenticationCredentials credentials = apiClient.getCredentials();
-    assertEquals(null, credentials);
   }
 
   @Test
-  public void testLookupRoles() {
+  public void testLookupRoles() throws IOException {
     apiClient.login(mdsUser, mdsPassword);
     apiClient.authenticate();
     apiClient.setKafkaClusterId(getKafkaClusterID());
@@ -62,7 +60,7 @@ public class MDSApiClientRbacIT extends MDSBaseTest {
   }
 
   @Test
-  public void testBindRoleToResource() {
+  public void testBindRoleToResource() throws IOException {
     apiClient.login(mdsUser, mdsPassword);
     apiClient.authenticate();
     apiClient.setKafkaClusterId(getKafkaClusterID());


### PR DESCRIPTION
Add an option to not delete internal topics, including an option configure rules to filter internal topics that can't not be removed config with  _kafka.internal.topic.prefixes_, by default this filters all topics starting with underscore. Users can configure more than one filter in the property file.

fixes #39