### PR TITLE
Make internal topics and groups configurable for Kafka Connect, Schema Registry and Control center

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@ v1.0.0-rc2:
 * Update Log4j version to 2.13.3 to prevent CVE-2020-9488
 * Add an option to not delete internal topics, including an option configure rules to filter internal topics that can't not be removed config with  _kafka.internal.topic.prefixes_,
 by default this filters all topics starting with underscore. Users can configure more than one filter in the property file.
+* Made internal topics for Kafka Connect, Schema Registry and Confluent Control Center configurable.
+By introducing this, users can now handle non-standard instances of Schema Registry or having for example more than
+a single Kafka Connect cluster (situation more than common).
 
 v1.0.0-rc1:
 * Add support for platform wide acls for control center in teh topology description file.

--- a/example/descriptor.yaml
+++ b/example/descriptor.yaml
@@ -20,6 +20,10 @@ projects:
             - "topicD"
     connectors:
       - principal: "User:Connect1"
+        group: "group"
+        status_topic: "status"
+        offset_topic: "offset"
+        configs_topic: "configs"
         topics:
           read:
             - "topicA"
@@ -48,7 +52,11 @@ projects:
           num.partitions: "1"
 platform:
   schema_registry:
-    - principal: "User:SchemaRegistry"
+    - principal: "User:SchemaRegistry01"
+      topic: "foo"
+      group: "bar"
+    - principal: "User:SchemaRegistry02"
+      topic: "zet"
   control_center:
     - principal: "User:ControlCenter"
       appId: "controlcenter"

--- a/src/main/conf/topology-builder.properties
+++ b/src/main/conf/topology-builder.properties
@@ -36,3 +36,9 @@
 # topology.builder.mds.kafka.cluster.id = "foobar"
 # topology.builder.mds.schema.registry.cluster.id = "schema-registry-cluster"
 # topology.builder.mds.kafka.connect.cluster.id = "connect-cluster"
+
+
+## Control Center internal topics
+# confluent.command.topic = _confluent-command
+# confluent.monitoring.topic = _confluent-monitoring
+# confluent.metrics.topic = _confluent-metrics

--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -112,8 +112,7 @@ public class AccessControlManager {
     // Sync platform relevant Access Control List.
     Platform platform = topology.getPlatform();
     for (SchemaRegistry schemaRegistry : platform.getSchemaRegistry()) {
-      List<TopologyAclBinding> bindings =
-          controlProvider.setAclsForSchemaRegistry(schemaRegistry.getPrincipal());
+      List<TopologyAclBinding> bindings = controlProvider.setAclsForSchemaRegistry(schemaRegistry);
       clusterState.update(bindings);
     }
 

--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -144,9 +144,7 @@ public class AccessControlManager {
           controlProvider.setAclsForStreamsApp(
               app.getPrincipal(), topicPrefix, readTopics, writeTopics);
     } else if (app instanceof Connector) {
-      bindings =
-          controlProvider.setAclsForConnect(
-              app.getPrincipal(), topicPrefix, readTopics, writeTopics);
+      bindings = controlProvider.setAclsForConnect((Connector) app, topicPrefix);
     }
     clusterState.update(bindings);
   }

--- a/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
@@ -1,6 +1,7 @@
 package com.purbon.kafka.topology;
 
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
+import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.util.Collection;
@@ -30,7 +31,8 @@ public interface AccessControlProvider {
 
   Map<String, List<TopologyAclBinding>> listAcls();
 
-  List<TopologyAclBinding> setAclsForSchemaRegistry(String principal) throws ConfigurationException;
+  List<TopologyAclBinding> setAclsForSchemaRegistry(SchemaRegistry schemaRegistry)
+      throws ConfigurationException;
 
   List<TopologyAclBinding> setAclsForControlCenter(String principal, String appId);
 }

--- a/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
@@ -1,6 +1,7 @@
 package com.purbon.kafka.topology;
 
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
+import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
@@ -12,8 +13,7 @@ public interface AccessControlProvider {
 
   void clearAcls(ClusterState clusterState);
 
-  List<TopologyAclBinding> setAclsForConnect(
-      String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics)
+  List<TopologyAclBinding> setAclsForConnect(Connector connector, String topicPrefix)
       throws IOException;
 
   List<TopologyAclBinding> setAclsForStreamsApp(

--- a/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
@@ -52,7 +52,7 @@ public class KafkaTopologyBuilder {
         topologyFile,
         new TopologySerdes(),
         new TopologyBuilderConfig(cliParams, buildProperties(cliParams)),
-        buildTopologyAdminClient(cliParams),
+        buildTopologyAdminClient(new TopologyBuilderConfig(cliParams, buildProperties(cliParams))),
         Boolean.valueOf(cliParams.getOrDefault(QUITE_OPTION, "false")));
   }
 
@@ -226,10 +226,9 @@ public class KafkaTopologyBuilder {
     return props;
   }
 
-  private static TopologyBuilderAdminClient buildTopologyAdminClient(
-      Map<String, String> cliParams) {
-    AdminClient kafkaAdminClient = buildKafkaAdminClient(cliParams);
-    return new TopologyBuilderAdminClient(kafkaAdminClient);
+  private static TopologyBuilderAdminClient buildTopologyAdminClient(TopologyBuilderConfig config) {
+    AdminClient kafkaAdminClient = buildKafkaAdminClient(config.params());
+    return new TopologyBuilderAdminClient(kafkaAdminClient, config);
   }
 
   private static AdminClient buildKafkaAdminClient(Map<String, String> cliParams) {

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
@@ -43,9 +43,11 @@ public class TopologyBuilderAdminClient {
   private static final Logger LOGGER = LogManager.getLogger(TopologyBuilderAdminClient.class);
 
   private final AdminClient adminClient;
+  private final TopologyBuilderConfig config;
 
-  public TopologyBuilderAdminClient(AdminClient adminClient) {
+  public TopologyBuilderAdminClient(AdminClient adminClient, TopologyBuilderConfig config) {
     this.adminClient = adminClient;
+    this.config = config;
   }
 
   public Set<String> listTopics(ListTopicsOptions options) throws IOException {
@@ -272,7 +274,10 @@ public class TopologyBuilderAdminClient {
     bindings.add(
         buildGroupLevelAcl(principal, appId + "-command", PatternType.PREFIXED, AclOperation.READ));
 
-    Arrays.asList("_confluent-monitoring", "_confluent-command", " _confluent-metrics")
+    Arrays.asList(
+            config.getConfluentMonitoringTopic(),
+            config.getConfluentCommandTopic(),
+            config.getConfluentMetricsTopic())
         .forEach(
             topic ->
                 Stream.of(

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
@@ -2,6 +2,7 @@ package com.purbon.kafka.topology;
 
 import com.purbon.kafka.topology.adminclient.AclBuilder;
 import com.purbon.kafka.topology.model.Topic;
+import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -246,13 +247,17 @@ public class TopologyBuilderAdminClient {
     return acls;
   }
 
-  public List<AclBinding> setAclForSchemaRegistry(String principal) throws IOException {
+  public List<AclBinding> setAclForSchemaRegistry(SchemaRegistry schemaRegistry)
+      throws IOException {
     List<AclBinding> bindings =
         Arrays.asList(AclOperation.DESCRIBE_CONFIGS, AclOperation.WRITE, AclOperation.READ).stream()
             .map(
                 aclOperation -> {
                   return buildTopicLevelAcl(
-                      principal, "_schemas", PatternType.LITERAL, aclOperation);
+                      schemaRegistry.getPrincipal(),
+                      schemaRegistry.getTopic(),
+                      PatternType.LITERAL,
+                      aclOperation);
                 })
             .collect(Collectors.toList());
     createAcls(bindings);

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
@@ -355,7 +355,8 @@ public class TopologyBuilderAdminClient {
         new AccessControlEntry(principal, "*", AclOperation.CREATE, AclPermissionType.ALLOW);
     acls.add(new AclBinding(resourcePattern, entry));
 
-    resourcePattern = new ResourcePattern(ResourceType.GROUP, connector.getGroup(), PatternType.LITERAL);
+    resourcePattern =
+        new ResourcePattern(ResourceType.GROUP, connector.getGroup(), PatternType.LITERAL);
     entry = new AccessControlEntry(principal, "*", AclOperation.READ, AclPermissionType.ALLOW);
     acls.add(new AclBinding(resourcePattern, entry));
 

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
@@ -355,7 +355,7 @@ public class TopologyBuilderAdminClient {
         new AccessControlEntry(principal, "*", AclOperation.CREATE, AclPermissionType.ALLOW);
     acls.add(new AclBinding(resourcePattern, entry));
 
-    resourcePattern = new ResourcePattern(ResourceType.GROUP, "*", PatternType.LITERAL);
+    resourcePattern = new ResourcePattern(ResourceType.GROUP, connector.getGroup(), PatternType.LITERAL);
     entry = new AccessControlEntry(principal, "*", AclOperation.READ, AclPermissionType.ALLOW);
     acls.add(new AclBinding(resourcePattern, entry));
 

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
@@ -2,6 +2,7 @@ package com.purbon.kafka.topology;
 
 import com.purbon.kafka.topology.adminclient.AclBuilder;
 import com.purbon.kafka.topology.model.Topic;
+import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
@@ -331,13 +332,18 @@ public class TopologyBuilderAdminClient {
     return acls;
   }
 
-  public List<AclBinding> setAclsForConnect(
-      String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics)
-      throws IOException {
+  public List<AclBinding> setAclsForConnect(Connector connector) throws IOException {
+
+    String principal = connector.getPrincipal();
+    List<String> readTopics = connector.getTopics().get("read");
+    List<String> writeTopics = connector.getTopics().get("write");
 
     List<AclBinding> acls = new ArrayList<>();
 
-    List<String> topics = Arrays.asList("connect-status", "connect-offsets", "connect-configs");
+    List<String> topics =
+        Arrays.asList(
+            connector.getStatus_topic(), connector.getOffset_topic(), connector.getConfigs_topic());
+
     for (String topic : topics) {
       acls.add(buildTopicLevelAcl(principal, topic, PatternType.LITERAL, AclOperation.READ));
       acls.add(buildTopicLevelAcl(principal, topic, PatternType.LITERAL, AclOperation.WRITE));

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -43,6 +43,15 @@ public class TopologyBuilderConfig {
   public static final String MDS_KC_CLUSTER_ID_CONFIG =
       "topology.builder.mds.kafka.connect.cluster.id";
 
+  public static final String CONFLUENT_MONITORING_TOPIC_CONFIG = "confluent.monitoring.topic";
+  public static final String CONFLUENT_MONITORING_TOPIC_DEFAULT = "_confluent-monitoring";
+
+  public static final String CONFLUENT_COMMAND_TOPIC_CONFIG = "confluent.command.topic";
+  public static final String CONFLUENT_COMMAND_TOPIC_DEFAULT = "_confluent-command";
+
+  public static final String CONFLUENT_METRICS_TOPIC_CONFIG = "confluent.metrics.topic";
+  public static final String CONFLUENT_METRICS_TOPIC_DEFAULT = "_confluent-metrics";
+
   private final Map<String, String> cliParams;
   private final Properties properties;
 
@@ -114,5 +123,23 @@ public class TopologyBuilderConfig {
 
   public Object getOrDefault(Object key, Object _default) {
     return properties.getOrDefault(key, _default);
+  }
+
+  public String getConfluentMonitoringTopic() {
+    return properties
+        .getOrDefault(CONFLUENT_MONITORING_TOPIC_CONFIG, CONFLUENT_MONITORING_TOPIC_DEFAULT)
+        .toString();
+  }
+
+  public String getConfluentCommandTopic() {
+    return properties
+        .getOrDefault(CONFLUENT_COMMAND_TOPIC_CONFIG, CONFLUENT_COMMAND_TOPIC_DEFAULT)
+        .toString();
+  }
+
+  public String getConfluentMetricsTopic() {
+    return properties
+        .getOrDefault(CONFLUENT_METRICS_TOPIC_CONFIG, CONFLUENT_METRICS_TOPIC_DEFAULT)
+        .toString();
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/model/users/Connector.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/Connector.java
@@ -14,6 +14,8 @@ public class Connector extends DynamicUser {
   private static final String DEFAULT_CONNECT_CONFIGS_TOPIC = "connect-configs";
   private static final String DEFAULT_CONNECT_GROUP = "connect-cluster";
 
+  private static final String DEFAULT_CONNECT_CLUSTER_ID = "connect-cluster";
+
   @JsonInclude(Include.NON_EMPTY)
   private Optional<String> status_topic;
 
@@ -26,6 +28,9 @@ public class Connector extends DynamicUser {
   @JsonInclude(Include.NON_EMPTY)
   private Optional<String> group;
 
+  @JsonInclude(Include.NON_EMPTY)
+  private Optional<String> cluster_id;
+
   public Connector() {
     this("");
   }
@@ -34,6 +39,7 @@ public class Connector extends DynamicUser {
     this(
         principal,
         new HashMap<>(),
+        Optional.empty(),
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
@@ -46,7 +52,8 @@ public class Connector extends DynamicUser {
       Optional<String> status_topic,
       Optional<String> offset_topic,
       Optional<String> configs_topic,
-      Optional<String> group) {
+      Optional<String> group,
+      Optional<String> cluster_id) {
 
     super(principal, topics);
 
@@ -54,6 +61,7 @@ public class Connector extends DynamicUser {
     this.status_topic = status_topic;
     this.offset_topic = offset_topic;
     this.group = group;
+    this.cluster_id = cluster_id;
   }
 
   public String getStatus_topic() {
@@ -86,5 +94,13 @@ public class Connector extends DynamicUser {
 
   public void setGroup(Optional<String> group) {
     this.group = group;
+  }
+
+  public Optional<String> getCluster_id() {
+    return cluster_id;
+  }
+
+  public void setCluster_id(Optional<String> cluster_id) {
+    this.cluster_id = cluster_id;
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/model/users/Connector.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/Connector.java
@@ -1,15 +1,90 @@
 package com.purbon.kafka.topology.model.users;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.purbon.kafka.topology.model.DynamicUser;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
 
 public class Connector extends DynamicUser {
 
+  private static final String DEFAULT_CONNECT_STATUS_TOPIC = "connect-status";
+  private static final String DEFAULT_CONNECT_OFFSET_TOPIC = "connect-offsets";
+  private static final String DEFAULT_CONNECT_CONFIGS_TOPIC = "connect-configs";
+  private static final String DEFAULT_CONNECT_GROUP = "connect-cluster";
+
+  @JsonInclude(Include.NON_EMPTY)
+  private Optional<String> status_topic;
+
+  @JsonInclude(Include.NON_EMPTY)
+  private Optional<String> offset_topic;
+
+  @JsonInclude(Include.NON_EMPTY)
+  private Optional<String> configs_topic;
+
+  @JsonInclude(Include.NON_EMPTY)
+  private Optional<String> group;
+
   public Connector() {
-    super();
+    this("");
   }
 
   public Connector(String principal) {
-    super(principal, new HashMap<>());
+    this(
+        principal,
+        new HashMap<>(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  public Connector(
+      String principal,
+      HashMap<String, List<String>> topics,
+      Optional<String> status_topic,
+      Optional<String> offset_topic,
+      Optional<String> configs_topic,
+      Optional<String> group) {
+
+    super(principal, topics);
+
+    this.configs_topic = configs_topic;
+    this.status_topic = status_topic;
+    this.offset_topic = offset_topic;
+    this.group = group;
+  }
+
+  public String getStatus_topic() {
+    return status_topic.orElse(DEFAULT_CONNECT_STATUS_TOPIC);
+  }
+
+  public void setStatus_topic(Optional<String> status_topic) {
+    this.status_topic = status_topic;
+  }
+
+  public String getOffset_topic() {
+    return offset_topic.orElse(DEFAULT_CONNECT_OFFSET_TOPIC);
+  }
+
+  public void setOffset_topic(Optional<String> offset_topic) {
+    this.offset_topic = offset_topic;
+  }
+
+  public String getConfigs_topic() {
+    return configs_topic.orElse(DEFAULT_CONNECT_CONFIGS_TOPIC);
+  }
+
+  public void setConfigs_topic(Optional<String> configs_topic) {
+    this.configs_topic = configs_topic;
+  }
+
+  public String getGroup() {
+    return group.orElse(DEFAULT_CONNECT_GROUP);
+  }
+
+  public void setGroup(Optional<String> group) {
+    this.group = group;
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/model/users/SchemaRegistry.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/SchemaRegistry.java
@@ -7,6 +7,10 @@ import java.util.Optional;
 
 public class SchemaRegistry extends User {
 
+  private static final String DEFAULT_SCHEMA_TOPIC = "_schemas";
+
+  private static final String DEFAULT_SCHEMA_REGISTRY_GROUP = "schema-registry";
+
   @JsonInclude(Include.NON_EMPTY)
   private Optional<String> topic;
 
@@ -27,7 +31,7 @@ public class SchemaRegistry extends User {
   }
 
   public String getTopic() {
-    return topic.orElse("_schemas");
+    return topic.orElse(DEFAULT_SCHEMA_TOPIC);
   }
 
   public void setTopic(Optional<String> topic) {
@@ -35,7 +39,7 @@ public class SchemaRegistry extends User {
   }
 
   public String getGroup() {
-    return group.orElse("schema-registry");
+    return group.orElse(DEFAULT_SCHEMA_REGISTRY_GROUP);
   }
 
   public void setGroup(Optional<String> group) {

--- a/src/main/java/com/purbon/kafka/topology/model/users/SchemaRegistry.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/SchemaRegistry.java
@@ -1,5 +1,44 @@
 package com.purbon.kafka.topology.model.users;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.purbon.kafka.topology.model.User;
+import java.util.Optional;
 
-public class SchemaRegistry extends User {}
+public class SchemaRegistry extends User {
+
+  @JsonInclude(Include.NON_EMPTY)
+  private Optional<String> topic;
+
+  private Optional<String> group;
+
+  public SchemaRegistry() {
+    this("");
+  }
+
+  public SchemaRegistry(String principal) {
+    this(principal, Optional.empty(), Optional.empty());
+  }
+
+  public SchemaRegistry(String principal, Optional<String> topic, Optional<String> group) {
+    super(principal);
+    this.topic = topic;
+    this.group = group;
+  }
+
+  public String getTopic() {
+    return topic.orElse("_schemas");
+  }
+
+  public void setTopic(Optional<String> topic) {
+    this.topic = topic;
+  }
+
+  public String getGroup() {
+    return group.orElse("schema-registry");
+  }
+
+  public void setGroup(Optional<String> group) {
+    this.group = group;
+  }
+}

--- a/src/main/java/com/purbon/kafka/topology/roles/AdminRoleRunner.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/AdminRoleRunner.java
@@ -6,9 +6,11 @@ import static com.purbon.kafka.topology.api.mds.MDSApiClient.SCHEMA_REGISTRY_CLU
 
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
+import com.purbon.kafka.topology.model.users.Connector;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class AdminRoleRunner {
 
@@ -53,12 +55,19 @@ public class AdminRoleRunner {
     return this;
   }
 
-  public AdminRoleRunner forKafkaConnect() throws IOException {
+  public AdminRoleRunner forKafkaConnect(Connector connector) throws IOException {
     Map<String, String> clusterIds = new HashMap<>();
     Map<String, String> allClusterIds = client.getClusterIds().get("clusters");
+    validateRequiredClusterLabels(allClusterIds, KAFKA_CLUSTER_ID_LABEL);
+
+    Optional<String> connectClusterIdOptional = connector.getCluster_id();
     validateRequiredClusterLabels(allClusterIds, KAFKA_CLUSTER_ID_LABEL, CONNECT_CLUSTER_ID_LABEL);
+
+    String connectClusterID =
+        connectClusterIdOptional.orElse(allClusterIds.get(CONNECT_CLUSTER_ID_LABEL));
+
     clusterIds.put(KAFKA_CLUSTER_ID_LABEL, allClusterIds.get(KAFKA_CLUSTER_ID_LABEL));
-    clusterIds.put(CONNECT_CLUSTER_ID_LABEL, allClusterIds.get(CONNECT_CLUSTER_ID_LABEL));
+    clusterIds.put(CONNECT_CLUSTER_ID_LABEL, connectClusterID);
 
     scope.clear();
     scope.put("clusters", clusterIds);

--- a/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
@@ -11,6 +11,7 @@ import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.api.mds.RequestScope;
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
+import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,9 +56,12 @@ public class RBACProvider implements AccessControlProvider {
   }
 
   @Override
-  public List<TopologyAclBinding> setAclsForConnect(
-      String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics)
+  public List<TopologyAclBinding> setAclsForConnect(Connector connector, String topicPrefix)
       throws IOException {
+
+    String principal = connector.getPrincipal();
+    List<String> readTopics = connector.getTopics().get("read");
+    List<String> writeTopics = connector.getTopics().get("write");
 
     List<TopologyAclBinding> bindings = new ArrayList<>();
 
@@ -83,10 +87,10 @@ public class RBACProvider implements AccessControlProvider {
 
     String[] resources =
         new String[] {
-          "Topic:connect-configs",
-          "Topic:connect-offsets",
-          "Topic:connect-status",
-          "Group:connect-cluster",
+          "Topic:" + connector.getConfigs_topic(),
+          "Topic:" + connector.getOffset_topic(),
+          "Topic:" + connector.getStatus_topic(),
+          "Group:" + connector.getGroup(),
           "Group:secret-registry",
           "Topic:_confluent-secrets"
         };

--- a/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
@@ -66,7 +66,7 @@ public class RBACProvider implements AccessControlProvider {
     List<TopologyAclBinding> bindings = new ArrayList<>();
 
     TopologyAclBinding secAdminBinding =
-        apiClient.bind(principal, SECURITY_ADMIN).forKafkaConnect().apply();
+        apiClient.bind(principal, SECURITY_ADMIN).forKafkaConnect(connector).apply();
     bindings.add(secAdminBinding);
 
     apiClient.bind(principal, DEVELOPER_READ, topicPrefix, PREFIX);

--- a/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
@@ -11,6 +11,7 @@ import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.api.mds.RequestScope;
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
+import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -166,15 +167,17 @@ public class RBACProvider implements AccessControlProvider {
   }
 
   @Override
-  public List<TopologyAclBinding> setAclsForSchemaRegistry(String principal)
+  public List<TopologyAclBinding> setAclsForSchemaRegistry(SchemaRegistry schemaRegistry)
       throws ConfigurationException {
+    String principal = schemaRegistry.getPrincipal();
     List<TopologyAclBinding> bindings = new ArrayList<>();
     TopologyAclBinding binding =
         apiClient.bind(principal, SECURITY_ADMIN).forSchemaRegistry().apply();
     bindings.add(binding);
-    binding = apiClient.bind(principal, RESOURCE_OWNER, "_schemas", LITERAL);
+    binding = apiClient.bind(principal, RESOURCE_OWNER, schemaRegistry.getTopic(), LITERAL);
     bindings.add(binding);
-    binding = apiClient.bind(principal, RESOURCE_OWNER, "schema-registry", "Group", LITERAL);
+    binding =
+        apiClient.bind(principal, RESOURCE_OWNER, schemaRegistry.getGroup(), "Group", LITERAL);
     bindings.add(binding);
     return bindings;
   }

--- a/src/main/java/com/purbon/kafka/topology/roles/SimpleAclsProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/SimpleAclsProvider.java
@@ -3,6 +3,7 @@ package com.purbon.kafka.topology.roles;
 import com.purbon.kafka.topology.AccessControlProvider;
 import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -97,9 +98,9 @@ public class SimpleAclsProvider implements AccessControlProvider {
   }
 
   @Override
-  public List<TopologyAclBinding> setAclsForSchemaRegistry(String principal) {
+  public List<TopologyAclBinding> setAclsForSchemaRegistry(SchemaRegistry schemaRegistry) {
     try {
-      return adminClient.setAclForSchemaRegistry(principal).stream()
+      return adminClient.setAclForSchemaRegistry(schemaRegistry).stream()
           .map(aclBinding -> new TopologyAclBinding(aclBinding))
           .collect(Collectors.toList());
     } catch (IOException e) {

--- a/src/main/java/com/purbon/kafka/topology/roles/SimpleAclsProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/SimpleAclsProvider.java
@@ -3,6 +3,7 @@ package com.purbon.kafka.topology.roles;
 import com.purbon.kafka.topology.AccessControlProvider;
 import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,10 +40,9 @@ public class SimpleAclsProvider implements AccessControlProvider {
   }
 
   @Override
-  public List<TopologyAclBinding> setAclsForConnect(
-      String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics) {
+  public List<TopologyAclBinding> setAclsForConnect(Connector connector, String topicPrefix) {
     try {
-      return adminClient.setAclsForConnect(principal, topicPrefix, readTopics, writeTopics).stream()
+      return adminClient.setAclsForConnect(connector).stream()
           .map(TopologyAclBinding::new)
           .collect(Collectors.toList());
     } catch (IOException e) {

--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -144,11 +144,9 @@ public class AccessControlManagerTest {
 
     accessControlManager.sync(topology);
 
-    doReturn(new ArrayList<TopologyAclBinding>())
-        .when(aclsProvider)
-        .setAclsForSchemaRegistry("User:foo");
+    doReturn(new ArrayList<TopologyAclBinding>()).when(aclsProvider).setAclsForSchemaRegistry(sr);
 
-    verify(aclsProvider, times(1)).setAclsForSchemaRegistry("User:foo");
+    verify(aclsProvider, times(1)).setAclsForSchemaRegistry(sr);
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -193,16 +193,8 @@ public class AccessControlManagerTest {
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsProvider)
-        .setAclsForConnect(
-            "User:Connect1",
-            topicPrefix,
-            topics.get(KStream.READ_TOPICS),
-            topics.get(KStream.WRITE_TOPICS));
-    verify(aclsProvider, times(1))
-        .setAclsForConnect(
-            eq("User:Connect1"),
-            eq(topicPrefix),
-            eq(topics.get(KStream.READ_TOPICS)),
-            eq(topics.get(KStream.WRITE_TOPICS)));
+        .setAclsForConnect(connector1, topicPrefix);
+
+    verify(aclsProvider, times(1)).setAclsForConnect(eq(connector1), eq(topicPrefix));
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/AdminRoleRunnerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AdminRoleRunnerTest.java
@@ -9,11 +9,13 @@ import static org.mockito.Mockito.when;
 
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
+import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.roles.AdminRoleRunner;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,9 +31,10 @@ public class AdminRoleRunnerTest {
 
   private static Map<String, Map<String, String>> allClusterIds;
   private static Map<String, Map<String, String>> noClusterIds;
+  private Connector connector;
 
   @BeforeClass
-  public static void before() {
+  public static void beforeClass() {
 
     Map<String, String> allIds = new HashMap<>();
 
@@ -43,13 +46,18 @@ public class AdminRoleRunnerTest {
     noClusterIds = Collections.singletonMap("clusters", new HashMap<>());
   }
 
+  @Before
+  public void before() {
+    connector = new Connector();
+  }
+
   @Test
   public void testWithAllClientIdsForConnect() throws IOException {
 
     when(apiClient.getClusterIds()).thenReturn(allClusterIds);
 
     AdminRoleRunner runner = new AdminRoleRunner("foo", SECURITY_ADMIN, apiClient);
-    runner.forKafkaConnect();
+    runner.forKafkaConnect(connector);
 
     assertEquals("kafka-connect", runner.getResourceName());
 
@@ -64,7 +72,7 @@ public class AdminRoleRunnerTest {
     when(apiClient.getClusterIds()).thenReturn(noClusterIds);
 
     AdminRoleRunner runner = new AdminRoleRunner("foo", SECURITY_ADMIN, apiClient);
-    runner.forKafkaConnect();
+    runner.forKafkaConnect(connector);
   }
 
   @Test

--- a/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologySerdesTest.java
@@ -173,6 +173,8 @@ public class TopologySerdesTest {
     List<SchemaRegistry> listOfSR = topology.getPlatform().getSchemaRegistry();
     assertEquals(2, listOfSR.size());
     assertEquals("User:SchemaRegistry01", listOfSR.get(0).getPrincipal());
+    assertEquals("foo", listOfSR.get(0).getTopic());
+    assertEquals("bar", listOfSR.get(0).getGroup());
     assertEquals("User:SchemaRegistry02", listOfSR.get(1).getPrincipal());
 
     List<ControlCenter> listOfC3 = topology.getPlatform().getControlCenter();

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -3,6 +3,7 @@ package com.purbon.kafka.topology.integration;
 import com.purbon.kafka.topology.AccessControlManager;
 import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.TopologyBuilderConfig;
 import com.purbon.kafka.topology.model.Platform;
 import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
@@ -36,7 +37,11 @@ import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 public class AccessControlManagerIT {
 
@@ -45,10 +50,15 @@ public class AccessControlManagerIT {
   private ClusterState cs;
   private SimpleAclsProvider aclsProvider;
 
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private TopologyBuilderConfig config;
+
   @Before
   public void before() throws IOException {
     kafkaAdminClient = AdminClient.create(config());
-    TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
+    TopologyBuilderAdminClient adminClient =
+        new TopologyBuilderAdminClient(kafkaAdminClient, config);
     adminClient.clearAcls();
 
     cs = new ClusterState();

--- a/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/AccessControlManagerIT.java
@@ -1,5 +1,7 @@
 package com.purbon.kafka.topology.integration;
 
+import static org.mockito.Mockito.when;
+
 import com.purbon.kafka.topology.AccessControlManager;
 import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.TopologyBuilderAdminClient;
@@ -192,6 +194,11 @@ public class AccessControlManagerIT {
   @Test
   public void controlcenterAclsCreation()
       throws ExecutionException, InterruptedException, IOException {
+
+    when(config.getConfluentCommandTopic()).thenReturn("foo");
+    when(config.getConfluentMetricsTopic()).thenReturn("bar");
+    when(config.getConfluentMonitoringTopic()).thenReturn("zet");
+
     Project project = new Project();
 
     Topology topology = new Topology();

--- a/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/TopicManagerIT.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.purbon.kafka.topology.TopicManager;
 import com.purbon.kafka.topology.TopologyBuilderAdminClient;
+import com.purbon.kafka.topology.TopologyBuilderConfig;
 import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.model.Topology;
@@ -28,7 +29,11 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.testcontainers.containers.KafkaContainer;
 
 public class TopicManagerIT {
@@ -36,6 +41,10 @@ public class TopicManagerIT {
   private static KafkaContainer container;
   private TopicManager topicManager;
   private AdminClient kafkaAdminClient;
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private TopologyBuilderConfig config;
 
   @BeforeClass
   public static void setup() {
@@ -51,7 +60,8 @@ public class TopicManagerIT {
   @Before
   public void before() {
     kafkaAdminClient = AdminClient.create(config());
-    TopologyBuilderAdminClient adminClient = new TopologyBuilderAdminClient(kafkaAdminClient);
+    TopologyBuilderAdminClient adminClient =
+        new TopologyBuilderAdminClient(kafkaAdminClient, config);
 
     topicManager = new TopicManager(adminClient);
   }

--- a/src/test/resources/descriptor.yaml
+++ b/src/test/resources/descriptor.yaml
@@ -53,7 +53,10 @@ projects:
 platform:
   schema_registry:
     - principal: "User:SchemaRegistry01"
+      topic: "foo"
+      group: "bar"
     - principal: "User:SchemaRegistry02"
+      topic: "zet"
   control_center:
     - principal: "User:ControlCenter"
       appId: "controlcenter"

--- a/src/test/resources/descriptor.yaml
+++ b/src/test/resources/descriptor.yaml
@@ -17,6 +17,7 @@ projects:
             - "topicD"
     connectors:
       - principal: "User:Connect1"
+        cluster_id: "foo"
         group: "group"
         status_topic: "status"
         offset_topic: "offset"

--- a/src/test/resources/descriptor.yaml
+++ b/src/test/resources/descriptor.yaml
@@ -17,6 +17,10 @@ projects:
             - "topicD"
     connectors:
       - principal: "User:Connect1"
+        group: "group"
+        status_topic: "status"
+        offset_topic: "offset"
+        configs_topic: "configs"
         topics:
           read:
             - "topicA"

--- a/src/test/resources/descriptor.yaml
+++ b/src/test/resources/descriptor.yaml
@@ -3,11 +3,9 @@ team: "team"
 source: "source"
 projects:
   - name: "foo"
-    zookeepers: []
     consumers:
       - principal: "User:App0"
       - principal: "User:App1"
-    producers: []
     streams:
       - principal: "User:App0"
         topics:
@@ -39,11 +37,6 @@ projects:
           replication.factor: "1"
           num.partitions: "1"
   - name: "bar"
-    zookeepers: []
-    consumers: []
-    producers: []
-    streams: []
-    connectors: []
     topics:
       - dataType: "avro"
         name: "bar"


### PR DESCRIPTION
This PR makes internal topics of Kafka Connect, Schema Registry and Confluent Control Center configurable. By introducing this, users can now handle non-standard instances of Schema Registry or having for example more than a single Kafka Connect cluster (situation more than common).

fixes #46 

@jeanlouisboudart thoughts?