### PR TITLE
Specify custom consumer groups per consumer principal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Kafka Topology Builder library in a single and uniform web application that can 
 * Remove the requirement of writing in the configuration file the access control method, as of now will be ACLs as default value and if other (like RBAC) is required
 it will have to be properly configured.
 * Merge #22 to provide the initial support for schema management. Now you can manage schemas with Confluent Schema Registry using the Kafka Topology Builder. Thanks Kiril.
+* Add an option to specify custom consumer groups in the topology descriptor
 
 v1.0.0-rc1:
 * Add support for platform wide acls for control center in teh topology description file.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,8 @@ Contents
    :maxdepth: 2
 
    core-concepts
+   what-can-you-do
    workflow-setup
    powered-with
    config-values
+

--- a/docs/what-can-you-do.rst
+++ b/docs/what-can-you-do.rst
@@ -1,0 +1,45 @@
+What can you do with Kafka Topology Builder
+*******************************
+
+In a nutshell with Kafka Topology Builder you can manage your topics and acls in an structure and autonomous way.
+As well you can manage your topics schemas as register.
+
+In this chapter we will introduce the different things one can configure in each topology file(s).
+
+ACLs
+-----------
+
+In the topology descriptor files users can create permissions for different types of applications, Consumers, Producers, Kafka streams apps or Kafka Connectors.
+With this roles, users can easy create the permissions that map directly to their needs.
+
+Consumers
+^^^^^^^^^^^
+
+As a user you can configure consumers for each project.
+Consumer have a principal and optionally a consumer group name, if the consumer group is not defined a group ACL with "*" will be created.
+
+
+.. code-block:: YAML
+
+  ---
+    team: "team"
+    source: "source"
+    projects:
+      - name: "foo"
+        consumers:
+          - principal: "User:App0"
+
+Consumer definition with principal "User:App0" and without an specific consumer group, for this configuration an ACL will be created to accept any consumer group.
+
+.. code-block:: YAML
+
+  ---
+    team: "team"
+    source: "source"
+    projects:
+      - name: "foo"
+        consumers:
+          - principal: "User:App0"
+            group: "foo
+
+Consumer definition with principal "User:App0" and consumer group name "foo".

--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -82,11 +82,8 @@ public class AccessControlManager {
               topic -> {
                 final String fullTopicName = topic.toString();
 
-                Collection<String> consumerPrincipals =
-                    extractUsersToPrincipals(project.getConsumers());
-
                 List<TopologyAclBinding> consumerBindings =
-                    controlProvider.setAclsForConsumers(consumerPrincipals, fullTopicName);
+                    controlProvider.setAclsForConsumers(project.getConsumers(), fullTopicName);
                 clusterState.update(consumerBindings);
 
                 Collection<String> producerPrincipals =

--- a/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
@@ -2,6 +2,7 @@ package com.purbon.kafka.topology;
 
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.model.users.Connector;
+import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
@@ -19,7 +20,7 @@ public interface AccessControlProvider {
   List<TopologyAclBinding> setAclsForStreamsApp(
       String principal, String topicPrefix, List<String> readTopics, List<String> writeTopics);
 
-  List<TopologyAclBinding> setAclsForConsumers(Collection<String> principals, String topic);
+  List<TopologyAclBinding> setAclsForConsumers(Collection<Consumer> consumers, String topic);
 
   List<TopologyAclBinding> setAclsForProducers(Collection<String> principals, String topic);
 

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderAdminClient.java
@@ -3,6 +3,7 @@ package com.purbon.kafka.topology;
 import com.purbon.kafka.topology.adminclient.AclBuilder;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.model.users.Connector;
+import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
@@ -219,12 +220,20 @@ public class TopologyBuilderAdminClient {
     return acls;
   }
 
-  public List<AclBinding> setAclsForConsumer(String principal, String topic) throws IOException {
+  public List<AclBinding> setAclsForConsumer(Consumer consumer, String topic) throws IOException {
 
     List<AclBinding> acls = new ArrayList<>();
-    acls.add(buildTopicLevelAcl(principal, topic, PatternType.LITERAL, AclOperation.DESCRIBE));
-    acls.add(buildTopicLevelAcl(principal, topic, PatternType.LITERAL, AclOperation.READ));
-    acls.add(buildGroupLevelAcl(principal, "*", PatternType.LITERAL, AclOperation.READ));
+    acls.add(
+        buildTopicLevelAcl(
+            consumer.getPrincipal(), topic, PatternType.LITERAL, AclOperation.DESCRIBE));
+    acls.add(
+        buildTopicLevelAcl(consumer.getPrincipal(), topic, PatternType.LITERAL, AclOperation.READ));
+    acls.add(
+        buildGroupLevelAcl(
+            consumer.getPrincipal(),
+            consumer.groupString(),
+            consumer.groupString().equals("*") ? PatternType.PREFIXED : PatternType.LITERAL,
+            AclOperation.READ));
     createAcls(acls);
     return acls;
   }

--- a/src/main/java/com/purbon/kafka/topology/model/users/Consumer.java
+++ b/src/main/java/com/purbon/kafka/topology/model/users/Consumer.java
@@ -1,14 +1,50 @@
 package com.purbon.kafka.topology.model.users;
 
 import com.purbon.kafka.topology.model.User;
+import java.util.Objects;
+import java.util.Optional;
 
 public class Consumer extends User {
 
+  private Optional<String> group;
+
   public Consumer() {
     super();
+    group = Optional.empty();
   }
 
   public Consumer(String principal) {
     super(principal);
+    group = Optional.empty();
+  }
+
+  public String groupString() {
+    return group.orElse("*");
+  }
+
+  public Optional<String> getGroup() {
+    return group;
+  }
+
+  public void setGroup(Optional<String> group) {
+    this.group = group;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Consumer)) {
+      return false;
+    }
+    Consumer consumer = (Consumer) o;
+    return getPrincipal().equals(consumer.getPrincipal())
+        && groupString().equals(consumer.groupString());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(groupString(), getPrincipal());
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
@@ -12,6 +12,7 @@ import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.api.mds.RequestScope;
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.model.users.Connector;
+import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -138,11 +139,13 @@ public class RBACProvider implements AccessControlProvider {
   }
 
   @Override
-  public List<TopologyAclBinding> setAclsForConsumers(Collection<String> principals, String topic) {
+  public List<TopologyAclBinding> setAclsForConsumers(
+      Collection<Consumer> consumers, String topic) {
     List<TopologyAclBinding> bindings = new ArrayList<>();
-    principals.forEach(
-        principal -> {
-          TopologyAclBinding binding = apiClient.bind(principal, DEVELOPER_READ, topic, LITERAL);
+    consumers.forEach(
+        consumer -> {
+          TopologyAclBinding binding =
+              apiClient.bind(consumer.getPrincipal(), DEVELOPER_READ, topic, LITERAL);
           bindings.add(binding);
         });
     return bindings;

--- a/src/main/java/com/purbon/kafka/topology/roles/SimpleAclsProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/SimpleAclsProvider.java
@@ -4,6 +4,7 @@ import com.purbon.kafka.topology.AccessControlProvider;
 import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.TopologyBuilderAdminClient;
 import com.purbon.kafka.topology.model.users.Connector;
+import com.purbon.kafka.topology.model.users.Consumer;
 import com.purbon.kafka.topology.model.users.SchemaRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -66,13 +67,14 @@ public class SimpleAclsProvider implements AccessControlProvider {
   }
 
   @Override
-  public List<TopologyAclBinding> setAclsForConsumers(Collection<String> principals, String topic) {
-    return principals.stream()
+  public List<TopologyAclBinding> setAclsForConsumers(
+      Collection<Consumer> consumers, String topic) {
+    return consumers.stream()
         .flatMap(
-            principal -> {
+            consumer -> {
               List<AclBinding> acls = new ArrayList<>();
               try {
-                acls = adminClient.setAclsForConsumer(principal, topic);
+                acls = adminClient.setAclsForConsumer(consumer, topic);
               } catch (IOException e) {
                 LOGGER.error(e);
               }

--- a/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/AccessControlManagerTest.java
@@ -66,7 +66,7 @@ public class AccessControlManagerTest {
     Topology topology = new TopologyImpl();
     topology.addProject(project);
 
-    List<String> users = Arrays.asList(new String[] {"User:app1"});
+    List<Consumer> users = Arrays.asList(new Consumer("User:app1"));
 
     doReturn(new ArrayList<TopologyAclBinding>())
         .when(aclsProvider)

--- a/src/test/resources/descriptor.yaml
+++ b/src/test/resources/descriptor.yaml
@@ -5,6 +5,7 @@ projects:
   - name: "foo"
     consumers:
       - principal: "User:App0"
+        group: "foo"
       - principal: "User:App1"
     streams:
       - principal: "User:App0"


### PR DESCRIPTION
This pull request add the capability to specify custom consumer groups per each consumer principal or use as default the "*" as catch all method.

@sknop This is what we spoke offline the other day, does this fits your thoughts?