### PR TITLE
Fix bug on removal of acls 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ it will have to be properly configured.
 * Add support for connect level permissions in the rbac mode. This solve issue #45.
 * Implement an initial method for building an execution plan including an option to print a dry-run. This solve issue #62.
 * Rename team as context as it was a confusing wording. This solve issue #68.
+* Fix bug on removal of acls. This solve issue #72.
 
 v1.0.0-rc1:
 * Add support for platform wide acls for control center in teh topology description file.

--- a/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlManager.java
@@ -85,7 +85,7 @@ public class AccessControlManager {
     try {
       clusterState.load();
       if (allowDelete) {
-        plan.add(new ClearAcls(controlProvider, clusterState));
+        plan.add(new ClearAcls(controlProvider, clusterState.getBindings()));
       }
     } catch (Exception e) {
       LOGGER.error(e);

--- a/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/AccessControlProvider.java
@@ -11,10 +11,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface AccessControlProvider {
 
-  void clearAcls(ClusterState clusterState);
+  void clearAcls(Set<TopologyAclBinding> bindings);
 
   List<TopologyAclBinding> setAclsForConnect(Connector connector, String topicPrefix)
       throws IOException;

--- a/src/main/java/com/purbon/kafka/topology/ClusterState.java
+++ b/src/main/java/com/purbon/kafka/topology/ClusterState.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 
 public class ClusterState {
 
@@ -33,8 +32,8 @@ public class ClusterState {
     this.bindings.add(binding);
   }
 
-  public void forEachBinding(Consumer<? super TopologyAclBinding> action) {
-    bindings.forEach(action);
+  public Set<TopologyAclBinding> getBindings() {
+    return new HashSet<>(bindings);
   }
 
   public void flushAndClose() {

--- a/src/main/java/com/purbon/kafka/topology/actions/ClearAcls.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/ClearAcls.java
@@ -2,25 +2,26 @@ package com.purbon.kafka.topology.actions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.purbon.kafka.topology.AccessControlProvider;
-import com.purbon.kafka.topology.ClusterState;
+import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import com.purbon.kafka.topology.utils.JSON;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class ClearAcls implements Action {
 
   private final AccessControlProvider controlProvider;
-  private final ClusterState clusterState;
+  private final Set<TopologyAclBinding> bindingsForRemoval;
 
-  public ClearAcls(AccessControlProvider controlProvider, ClusterState clusterState) {
+  public ClearAcls(
+      AccessControlProvider controlProvider, Set<TopologyAclBinding> bindingsForRemoval) {
     this.controlProvider = controlProvider;
-    this.clusterState = clusterState;
+    this.bindingsForRemoval = bindingsForRemoval;
   }
 
   @Override
-  public void run() throws IOException {
-    controlProvider.clearAcls(clusterState);
+  public void run() {
+    controlProvider.clearAcls(bindingsForRemoval);
   }
 
   @Override

--- a/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/RBACProvider.java
@@ -7,7 +7,6 @@ import static com.purbon.kafka.topology.roles.RBACPredefinedRoles.SECURITY_ADMIN
 import static com.purbon.kafka.topology.roles.RBACPredefinedRoles.SYSTEM_ADMIN;
 
 import com.purbon.kafka.topology.AccessControlProvider;
-import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.api.mds.MDSApiClient;
 import com.purbon.kafka.topology.api.mds.RequestScope;
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
@@ -23,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,9 +40,9 @@ public class RBACProvider implements AccessControlProvider {
   }
 
   @Override
-  public void clearAcls(ClusterState clusterState) {
+  public void clearAcls(Set<TopologyAclBinding> bindings) {
     LOGGER.debug("RBACProvider: clearAcls");
-    clusterState.forEachBinding(
+    bindings.forEach(
         aclBinding -> {
           String principal = aclBinding.getPrincipal();
           String role = aclBinding.getOperation();

--- a/src/main/java/com/purbon/kafka/topology/roles/SimpleAclsProvider.java
+++ b/src/main/java/com/purbon/kafka/topology/roles/SimpleAclsProvider.java
@@ -1,7 +1,6 @@
 package com.purbon.kafka.topology.roles;
 
 import com.purbon.kafka.topology.AccessControlProvider;
-import com.purbon.kafka.topology.ClusterState;
 import com.purbon.kafka.topology.TopologyBuilderAdminClient;
 import com.purbon.kafka.topology.model.users.Connector;
 import com.purbon.kafka.topology.model.users.Consumer;
@@ -12,6 +11,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.logging.log4j.LogManager;
@@ -28,9 +28,9 @@ public class SimpleAclsProvider implements AccessControlProvider {
   }
 
   @Override
-  public void clearAcls(ClusterState clusterState) {
+  public void clearAcls(Set<TopologyAclBinding> bindings) {
     LOGGER.debug("AclsProvider: clearAcls");
-    clusterState.forEachBinding(
+    bindings.forEach(
         aclBinding -> {
           try {
             adminClient.clearAcls(aclBinding);


### PR DESCRIPTION
This PR fixes issue #72. As explained in the issue the problem was caused by the direct use of ClusterState in ClearAcls action for which bindings to remove. So solved it by refactoring ClearAcls to just take a list of bindings to be deleted - a copy of the list of bindings in ClusterState that is. 

Also replaced the integration test on this feature to simulate topology changes that should result in acl removals.

As a side note: I think it would be better to not delete all acls and then adding them again. But that can be discussed later :-)