### PR TITLE
Pass config values to the Schema Registry Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _build
 
 dependency-reduced-pom.xml
 server-api/logs/
+example/topology-builder-with-schema-cloud.properties

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ it will have to be properly configured.
 * Fix bug on removal of acls. This solve issue #72.
 * Fix bug with schema registration and file path reference,  now by default all are relative to the main directory where the topology file is staying.
 * Improved delete and general management of acls logic, only create what is necessary, only delete what is mandatory.
+* Fixed a problem with the schema registry client that got no configs, so it would not be possible to use with security contrain systems such as confluent cloud.
 
 v1.0.0-rc1:
 * Add support for platform wide acls for control center in teh topology description file.

--- a/scripts/run-docker-run-cmd.sh
+++ b/scripts/run-docker-run-cmd.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+docker run -t -i \
+      -v /Users/pere/work/kafka-topology-builder/example:/example \
+      purbon/kafka-topology-builder:srlatest \
+      kafka-topology-builder.sh \
+      --brokers pkc-4ygn6.europe-west3.gcp.confluent.cloud:9092 \
+      --clientConfig /example/topology-builder-with-schema-cloud.properties \
+      --topology /example/descriptor.yaml -quiet
+

--- a/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
@@ -12,6 +12,7 @@ import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.schemas.SchemaRegistryManager;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -70,8 +71,11 @@ public class KafkaTopologyBuilder implements AutoCloseable {
     AccessControlManager accessControlManager =
         new AccessControlManager(accessControlProvider, bindingsBuilderProvider, config);
 
+    RestService restService = new RestService(config.getConfluentSchemaRegistryUrl());
+    Map<String, ?> schemaRegistryConfig = config.asMap("schema.registry");
     SchemaRegistryClient schemaRegistryClient =
-        new CachedSchemaRegistryClient(config.getConfluentSchemaRegistryUrl(), 10);
+        new CachedSchemaRegistryClient(
+            restService, 10, schemaRegistryConfig.isEmpty() ? null : schemaRegistryConfig);
     SchemaRegistryManager schemaRegistryManager =
         new SchemaRegistryManager(schemaRegistryClient, topologyFileOrDir);
 

--- a/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
@@ -72,7 +72,7 @@ public class KafkaTopologyBuilder implements AutoCloseable {
         new AccessControlManager(accessControlProvider, bindingsBuilderProvider, config);
 
     RestService restService = new RestService(config.getConfluentSchemaRegistryUrl());
-    Map<String, ?> schemaRegistryConfig = config.asMap("schema.registry");
+    Map<String, ?> schemaRegistryConfig = config.asMap();
     SchemaRegistryClient schemaRegistryClient =
         new CachedSchemaRegistryClient(
             restService, 10, schemaRegistryConfig.isEmpty() ? null : schemaRegistryConfig);

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -80,6 +80,14 @@ public class TopologyBuilderConfig {
     this.properties = properties;
   }
 
+  public Map<String, ?> asMap(String filter) {
+    Map<String, Object> map = new HashMap<>();
+    properties.keySet().stream()
+        .filter(o -> String.valueOf(o).startsWith(filter))
+        .forEach(key -> map.put(String.valueOf(key), properties.get(key)));
+    return map;
+  }
+
   public void validateWith(Topology topology) throws ConfigurationException {
 
     validateGeneralConfiguration(topology);

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -52,7 +52,7 @@ public class TopologyBuilderConfig {
   public static final String MDS_KC_CLUSTER_ID_CONFIG =
       "topology.builder.mds.kafka.connect.cluster.id";
 
-  public static final String CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG = "confluent.schema.registry.url";
+  public static final String CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
   public static final String CONFLUENT_SCHEMA_REGISTRY_URL_DEFAULT = "mock://";
 
   public static final String CONFLUENT_MONITORING_TOPIC_CONFIG = "confluent.monitoring.topic";
@@ -80,10 +80,14 @@ public class TopologyBuilderConfig {
     this.properties = properties;
   }
 
+  public Map<String, ?> asMap() {
+    return asMap("");
+  }
+
   public Map<String, ?> asMap(String filter) {
     Map<String, Object> map = new HashMap<>();
     properties.keySet().stream()
-        .filter(o -> String.valueOf(o).startsWith(filter))
+        .filter(o -> filter.isEmpty() || String.valueOf(o).startsWith(filter))
         .forEach(key -> map.put(String.valueOf(key), properties.get(key)));
     return map;
   }

--- a/src/main/java/com/purbon/kafka/topology/actions/topics/SyncTopicAction.java
+++ b/src/main/java/com/purbon/kafka/topology/actions/topics/SyncTopicAction.java
@@ -57,11 +57,11 @@ public class SyncTopicAction extends BaseAction {
       final TopicSchemas schemas = topic.getSchemas();
 
       if (StringUtils.isNotBlank(schemas.getKeySchemaFile())) {
-        schemaRegistryManager.register(fullTopicName, schemas.getKeySchemaFile());
+        schemaRegistryManager.register(fullTopicName + "-key", schemas.getKeySchemaFile());
       }
 
       if (StringUtils.isNotBlank(schemas.getValueSchemaFile())) {
-        schemaRegistryManager.register(fullTopicName, schemas.getValueSchemaFile());
+        schemaRegistryManager.register(fullTopicName + "-value", schemas.getValueSchemaFile());
       }
     }
   }

--- a/src/test/resources/client-config-redis.properties
+++ b/src/test/resources/client-config-redis.properties
@@ -3,7 +3,7 @@ sasl.mechanism=PLAIN
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
   username="kafka" \
   password="kafka";
-confluent.schema.registry.url="http://localhost:8082"
+schema.registry.url="http://localhost:8082"
 
 topology.builder.state.processor.class=com.purbon.kafka.topology.clusterstate.RedisStateProcessor
 topology.builder.redis.host=foo

--- a/src/test/resources/client-config.properties
+++ b/src/test/resources/client-config.properties
@@ -3,4 +3,4 @@ sasl.mechanism=PLAIN
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
   username="kafka" \
   password="kafka";
-confluent.schema.registry.url="http://localhost:8082"
+schema.registry.url="http://localhost:8082"


### PR DESCRIPTION
Right now is possible to pass to the Schema Registry client configs passed in the property file for the schema registry client configs. This properties should be prefixed with _schema.registry_ as described in the Kafka Topology Builder class.
fixes #91 