### PR TITLE
Add a configuration management library

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,7 +24,8 @@ it will have to be properly configured.
 * Fixed a problem with the schema registry client that got no configs, so it would not be possible to use with security contrain systems such as confluent cloud.
 * Add the possibility to define a topic and project pattern using the jinja format, like this users can tune the order of the variables without hampeting the full idea of the structure
 * Add a framework to add incoming validation for topology files, this could be configured with the topology.validations config array.
-
+* Added the lightbend config library to support a more structured config management, including usage of environment variables and multiple config formats.
+* Made the broker CLI param optional, however one of both config or CLI has to be present, CLI takes always precedence over the config value.
 
 v1.0.0-rc1:
 * Add support for platform wide acls for control center in teh topology description file.

--- a/docs/config-values.rst
+++ b/docs/config-values.rst
@@ -38,10 +38,10 @@ To configure it you can use:
 
 Configure the state management system.
 **Property**: *topology.builder.state.processor.class*
-**Default value**: "com.purbon.kafka.topology.clusterstate.FileBackend"
+**Default value**: "com.purbon.kafka.topology.backend.FileBackend"
 **values**:
- - File: "com.purbon.kafka.topology.clusterstate.FileBackend"
- - Redis: "com.purbon.kafka.topology.clusterstate.RedisBackend"
+ - File: "com.purbon.kafka.topology.backend.FileBackend"
+ - Redis: "com.purbon.kafka.topology.backend.RedisBackend"
 
 If you are using redis, you need to extend two other properties to setup the server location:
 ::

--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.hubspot.jinjava</groupId>
       <artifactId>jinjava</artifactId>
       <version>${jinjava.version}</version>

--- a/src/main/java/com/purbon/kafka/topology/BuilderCLI.java
+++ b/src/main/java/com/purbon/kafka/topology/BuilderCLI.java
@@ -53,7 +53,12 @@ public class BuilderCLI {
         Option.builder().longOpt(TOPOLOGY_OPTION).hasArg().desc(TOPOLOGY_DESC).required().build();
 
     final Option brokersListOption =
-        Option.builder().longOpt(BROKERS_OPTION).hasArg().desc(BROKERS_DESC).required().build();
+        Option.builder()
+            .longOpt(BROKERS_OPTION)
+            .hasArg()
+            .desc(BROKERS_DESC)
+            .required(false)
+            .build();
 
     final Option adminClientConfigFileOption =
         Option.builder()
@@ -114,7 +119,6 @@ public class BuilderCLI {
   }
 
   public static void main(String[] args) throws Exception {
-
     BuilderCLI cli = new BuilderCLI();
     cli.run(args);
     exit(0);
@@ -124,26 +128,21 @@ public class BuilderCLI {
     printHelpOrVersion(args);
     CommandLine cmd = parseArgsOrExit(args);
 
-    String topology = cmd.getOptionValue(TOPOLOGY_OPTION);
     Map<String, String> config = parseConfig(cmd);
 
-    processTopology(topology, config);
+    processTopology(cmd.getOptionValue(TOPOLOGY_OPTION), config);
     System.out.println("Kafka Topology updated");
   }
 
   private Map<String, String> parseConfig(CommandLine cmd) {
-    String brokersList = cmd.getOptionValue(BROKERS_OPTION);
-    boolean allowDelete = cmd.hasOption(ALLOW_DELETE_OPTION);
-    boolean dryRun = cmd.hasOption(DRY_RUN_OPTION);
-    boolean quiet = cmd.hasOption(QUIET_OPTION);
-    String adminClientConfigFile = cmd.getOptionValue(ADMIN_CLIENT_CONFIG_OPTION);
-
     Map<String, String> config = new HashMap<>();
-    config.put(BROKERS_OPTION, brokersList);
-    config.put(ALLOW_DELETE_OPTION, String.valueOf(allowDelete));
-    config.put(DRY_RUN_OPTION, String.valueOf(dryRun));
-    config.put(QUIET_OPTION, String.valueOf(quiet));
-    config.put(ADMIN_CLIENT_CONFIG_OPTION, adminClientConfigFile);
+    if (cmd.hasOption(BROKERS_OPTION)) {
+      config.put(BROKERS_OPTION, cmd.getOptionValue(BROKERS_OPTION));
+    }
+    config.put(ALLOW_DELETE_OPTION, String.valueOf(cmd.hasOption(ALLOW_DELETE_OPTION)));
+    config.put(DRY_RUN_OPTION, String.valueOf(cmd.hasOption(DRY_RUN_OPTION)));
+    config.put(QUIET_OPTION, String.valueOf(cmd.hasOption(QUIET_OPTION)));
+    config.put(ADMIN_CLIENT_CONFIG_OPTION, cmd.getOptionValue(ADMIN_CLIENT_CONFIG_OPTION));
     return config;
   }
 

--- a/src/main/java/com/purbon/kafka/topology/ClusterState.java
+++ b/src/main/java/com/purbon/kafka/topology/ClusterState.java
@@ -1,7 +1,7 @@
 package com.purbon.kafka.topology;
 
-import com.purbon.kafka.topology.clusterstate.Backend;
-import com.purbon.kafka.topology.clusterstate.FileBackend;
+import com.purbon.kafka.topology.backend.Backend;
+import com.purbon.kafka.topology.backend.FileBackend;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.util.HashSet;

--- a/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
@@ -8,8 +8,8 @@ import static com.purbon.kafka.topology.TopologyBuilderConfig.STATE_PROCESSOR_DE
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClientBuilder;
 import com.purbon.kafka.topology.api.mds.MDSApiClientBuilder;
-import com.purbon.kafka.topology.clusterstate.FileBackend;
-import com.purbon.kafka.topology.clusterstate.RedisBackend;
+import com.purbon.kafka.topology.backend.FileBackend;
+import com.purbon.kafka.topology.backend.RedisBackend;
 import com.purbon.kafka.topology.exceptions.ValidationException;
 import com.purbon.kafka.topology.model.Topology;
 import com.purbon.kafka.topology.schemas.SchemaRegistryManager;

--- a/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/KafkaTopologyBuilder.java
@@ -48,7 +48,7 @@ public class KafkaTopologyBuilder implements AutoCloseable {
   public static KafkaTopologyBuilder build(String topologyFile, Map<String, String> config)
       throws Exception {
 
-    TopologyBuilderConfig builderConfig = new TopologyBuilderConfig(config);
+    TopologyBuilderConfig builderConfig = TopologyBuilderConfig.build(config);
     TopologyBuilderAdminClient adminClient =
         new TopologyBuilderAdminClientBuilder(builderConfig).build();
     AccessControlProviderFactory factory =

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -33,9 +33,9 @@ public class TopologyBuilderConfig {
       "topology.builder.state.processor.class";
 
   public static final String STATE_PROCESSOR_DEFAULT_CLASS =
-      "com.purbon.kafka.topology.clusterstate.FileStateProcessor";
+      "com.purbon.kafka.topology.clusterstate.FileBackend";
   public static final String REDIS_STATE_PROCESSOR_CLASS =
-      "com.purbon.kafka.topology.clusterstate.RedisStateProcessor";
+      "com.purbon.kafka.topology.clusterstate.RedisBackend";
 
   static final String REDIS_HOST_CONFIG = "topology.builder.redis.host";
   static final String REDIS_PORT_CONFIG = "topology.builder.redis.port";

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -99,7 +99,7 @@ public class TopologyBuilderConfig {
     Map<String, Object> map = new HashMap<>();
     config.entrySet().stream()
         .filter(entry -> filter.isEmpty() || entry.getKey().startsWith(filter))
-        .forEach(entry -> map.put(entry.getKey(), entry.getValue()));
+        .forEach(entry -> map.put(entry.getKey(), entry.getValue().unwrapped()));
     return map;
   }
 

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -12,6 +12,7 @@ import com.typesafe.config.ConfigFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -185,8 +186,8 @@ public class TopologyBuilderConfig {
   private static long countOfSchemas(Topology topology) {
     return topology.getProjects().stream()
         .flatMap((Function<Project, Stream<Topic>>) project -> project.getTopics().stream())
-        .map(topic -> topic.getSchemas())
-        .filter(topicSchemas -> topicSchemas != null)
+        .map(Topic::getSchemas)
+        .filter(Objects::nonNull)
         .count();
   }
 

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -1,14 +1,14 @@
 package com.purbon.kafka.topology;
 
+import static com.purbon.kafka.topology.BuilderCLI.ADMIN_CLIENT_CONFIG_OPTION;
 import static com.purbon.kafka.topology.BuilderCLI.DRY_RUN_OPTION;
 
 import com.purbon.kafka.topology.exceptions.ConfigurationException;
 import com.purbon.kafka.topology.model.Project;
 import com.purbon.kafka.topology.model.Topic;
 import com.purbon.kafka.topology.model.Topology;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.Arrays;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,8 +21,6 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 public class TopologyBuilderConfig {
 
   public static final String KAFKA_INTERNAL_TOPIC_PREFIXES = "kafka.internal.topic.prefixes";
-  public static final String KAFKA_INTERNAL_TOPIC_PREFIXES_DEFAULT = "_";
-
   public static final String ACCESS_CONTROL_IMPLEMENTATION_CLASS =
       "topology.builder.access.control.class";
 
@@ -39,57 +37,58 @@ public class TopologyBuilderConfig {
   public static final String REDIS_STATE_PROCESSOR_CLASS =
       "com.purbon.kafka.topology.clusterstate.RedisStateProcessor";
 
-  public static final String REDIS_HOST_CONFIG = "topology.builder.redis.host";
-
-  public static final String REDIS_PORT_CONFIG = "topology.builder.redis.port";
+  static final String REDIS_HOST_CONFIG = "topology.builder.redis.host";
+  static final String REDIS_PORT_CONFIG = "topology.builder.redis.port";
 
   public static final String MDS_SERVER = "topology.builder.mds.server";
-  public static final String MDS_USER_CONFIG = "topology.builder.mds.user";
-  public static final String MDS_PASSWORD_CONFIG = "topology.builder.mds.password";
+  static final String MDS_USER_CONFIG = "topology.builder.mds.user";
+  static final String MDS_PASSWORD_CONFIG = "topology.builder.mds.password";
   public static final String MDS_KAFKA_CLUSTER_ID_CONFIG = "topology.builder.mds.kafka.cluster.id";
   public static final String MDS_SR_CLUSTER_ID_CONFIG =
       "topology.builder.mds.schema.registry.cluster.id";
   public static final String MDS_KC_CLUSTER_ID_CONFIG =
       "topology.builder.mds.kafka.connect.cluster.id";
 
-  public static final String CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
-  public static final String CONFLUENT_SCHEMA_REGISTRY_URL_DEFAULT = "mock://";
-
-  public static final String CONFLUENT_MONITORING_TOPIC_CONFIG = "confluent.monitoring.topic";
-  public static final String CONFLUENT_MONITORING_TOPIC_DEFAULT = "_confluent-monitoring";
-
-  public static final String CONFLUENT_COMMAND_TOPIC_CONFIG = "confluent.command.topic";
-  public static final String CONFLUENT_COMMAND_TOPIC_DEFAULT = "_confluent-command";
-
-  public static final String CONFLUENT_METRICS_TOPIC_CONFIG = "confluent.metrics.topic";
-  public static final String CONFLUENT_METRICS_TOPIC_DEFAULT = "_confluent-metrics";
-
-  public static final String TOPIC_PREFIX_FORMAT_CONFIG = "topology.topic.prefix.format";
-  public static final String TOPIC_PREFIX_FORMAT_DEFAULT = "default";
-
-  public static final String PROJECT_PREFIX_FORMAT_CONFIG = "topology.project.prefix.format";
-  public static final String PROJECT_PREFIX_FORMAT_DEFAULT = "default";
-
-  public static final String TOPIC_PREFIX_SEPARATOR_CONFIG = "topology.topic.prefix.separator";
-  public static final String TOPIC_PREFIX_SEPARATOR_DEFAULT = ".";
-
-  public static final String TOPOLOGY_VALIDATIONS_CONFIG = "topology.validations";
-  public static final String TOPOLOGY_VALIDATIONS_DEFAULT = "";
+  static final String CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
+  private static final String CONFLUENT_MONITORING_TOPIC_CONFIG = "confluent.monitoring.topic";
+  private static final String CONFLUENT_COMMAND_TOPIC_CONFIG = "confluent.command.topic";
+  private static final String CONFLUENT_METRICS_TOPIC_CONFIG = "confluent.metrics.topic";
+  static final String TOPIC_PREFIX_FORMAT_CONFIG = "topology.topic.prefix.format";
+  static final String PROJECT_PREFIX_FORMAT_CONFIG = "topology.project.prefix.format";
+  static final String TOPIC_PREFIX_SEPARATOR_CONFIG = "topology.topic.prefix.separator";
+  static final String TOPOLOGY_VALIDATIONS_CONFIG = "topology.validations";
 
   private final Map<String, String> cliParams;
-  private final Properties properties;
+  private Config config;
 
   public TopologyBuilderConfig() {
-    this(new HashMap<>(), new Properties());
+    this(new HashMap<>(), ConfigFactory.load());
   }
 
-  public TopologyBuilderConfig(Map<String, String> cliParams) {
-    this(cliParams, buildProperties(cliParams));
+  public static TopologyBuilderConfig build(Map<String, String> cliParams) {
+    return build(cliParams, cliParams.get(ADMIN_CLIENT_CONFIG_OPTION));
   }
 
-  public TopologyBuilderConfig(Map<String, String> cliParams, Properties properties) {
+  public static TopologyBuilderConfig build(Map<String, String> cliParams, String configFile) {
+    if (!configFile.isEmpty()) {
+      System.setProperty("config.file", configFile);
+    }
+    ConfigFactory.invalidateCaches();
+    Config config = ConfigFactory.load();
+    return new TopologyBuilderConfig(cliParams, config);
+  }
+
+  public TopologyBuilderConfig(Map<String, String> cliParams, Properties props) {
+    this(cliParams, (Map) props);
+  }
+
+  public TopologyBuilderConfig(Map<String, String> cliParams, Map<String, Object> props) {
+    this(cliParams, ConfigFactory.parseMap(props).withFallback(ConfigFactory.load()));
+  }
+
+  public TopologyBuilderConfig(Map<String, String> cliParams, Config config) {
     this.cliParams = cliParams;
-    this.properties = properties;
+    this.config = config;
   }
 
   public Map<String, ?> asMap() {
@@ -98,18 +97,15 @@ public class TopologyBuilderConfig {
 
   public Map<String, ?> asMap(String filter) {
     Map<String, Object> map = new HashMap<>();
-    properties.keySet().stream()
-        .filter(o -> filter.isEmpty() || String.valueOf(o).startsWith(filter))
-        .forEach(key -> map.put(String.valueOf(key), properties.get(key)));
+    config.entrySet().stream()
+        .filter(entry -> filter.isEmpty() || entry.getKey().startsWith(filter))
+        .forEach(entry -> map.put(entry.getKey(), entry.getValue()));
     return map;
   }
 
   public void validateWith(Topology topology) throws ConfigurationException {
-
     validateGeneralConfiguration(topology);
-
     boolean isRBAC = this.getAccessControlClassName().equalsIgnoreCase(RBAC_ACCESS_CONTROL_CLASS);
-
     if (isRBAC) {
       validateRBACConfiguration(topology);
     }
@@ -125,22 +121,20 @@ public class TopologyBuilderConfig {
 
     if (hasSchemaRegistry) {
       raiseIfNull(MDS_SR_CLUSTER_ID_CONFIG);
-    } else if (hasKafkaConnect && properties.getProperty(MDS_KC_CLUSTER_ID_CONFIG) == null) {
+    } else if (hasKafkaConnect && config.getString(MDS_KC_CLUSTER_ID_CONFIG) == null) {
       raiseIfNull(MDS_KC_CLUSTER_ID_CONFIG);
     }
   }
 
   private void validateGeneralConfiguration(Topology topology) throws ConfigurationException {
     if (countOfSchemas(topology) > 0) {
-      raiseIfNull(CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG);
+      raiseIfDefault(CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG, "mock://");
     }
     boolean topicPrefixDefinedButNotProjectPrefix =
-        !getTopicPrefixFormat().equals(TOPIC_PREFIX_FORMAT_DEFAULT)
-            && getProjectPrefixFormat().equals(PROJECT_PREFIX_FORMAT_DEFAULT);
+        !getTopicPrefixFormat().equals("default") && getProjectPrefixFormat().equals("default");
 
     boolean projectPrefixDefinedButNotTopicPrefix =
-        getTopicPrefixFormat().equals(TOPIC_PREFIX_FORMAT_DEFAULT)
-            && !getProjectPrefixFormat().equals(PROJECT_PREFIX_FORMAT_DEFAULT);
+        getTopicPrefixFormat().equals("default") && !getProjectPrefixFormat().equals("default");
 
     if (topicPrefixDefinedButNotProjectPrefix || projectPrefixDefinedButNotTopicPrefix) {
       throw new ConfigurationException(
@@ -164,100 +158,72 @@ public class TopologyBuilderConfig {
         .count();
   }
 
-  private void raiseIfNull(String... keys) throws ConfigurationException {
-    for (String key : keys) {
-      raiseIfValueIsNull(key, properties.getProperty(key));
+  private void raiseIfDefault(String key, String _default) throws ConfigurationException {
+    if (config.getString(key).equals(_default)) {
+      throw new ConfigurationException(
+          "Configuration key " + key + " should not have the default value " + _default);
     }
   }
 
-  private void raiseIfValueIsNull(String key, String value) throws ConfigurationException {
-    if (value == null) {
-      throw new ConfigurationException(
-          "Required configuration " + key + " is missing, please add it to your configuration");
+  private void raiseIfNull(String... keys) throws ConfigurationException {
+    try {
+      for (String key : keys) {
+        config.getString(key);
+      }
+    } catch (Exception ex) {
+      throw new ConfigurationException(ex.getMessage());
     }
   }
 
   public String getProperty(String key) {
-    return properties.getProperty(key);
-  }
-
-  public List<String> getPropertyAsList(String key, String defaultVal, String regexp) {
-    Object val = properties.getOrDefault(key, defaultVal);
-    return Arrays.asList(String.valueOf(val).split(regexp));
-  }
-
-  public Object getOrDefault(Object key, Object _default) {
-    return properties.getOrDefault(key, _default);
+    return config.getString(key);
   }
 
   public List<String> getKafkaInternalTopicPrefixes() {
-    return getPropertyAsList(
-            KAFKA_INTERNAL_TOPIC_PREFIXES, KAFKA_INTERNAL_TOPIC_PREFIXES_DEFAULT, ",")
-        .stream()
+    return config.getStringList(KAFKA_INTERNAL_TOPIC_PREFIXES).stream()
         .map(String::trim)
         .collect(Collectors.toList());
   }
 
   public String getConfluentSchemaRegistryUrl() {
-    return properties
-        .getOrDefault(CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG, CONFLUENT_SCHEMA_REGISTRY_URL_DEFAULT)
-        .toString();
+    return config.getString(CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG);
   }
 
   public String getConfluentMonitoringTopic() {
-    return properties
-        .getOrDefault(CONFLUENT_MONITORING_TOPIC_CONFIG, CONFLUENT_MONITORING_TOPIC_DEFAULT)
-        .toString();
+    return config.getString(CONFLUENT_MONITORING_TOPIC_CONFIG);
   }
 
   public String getConfluentCommandTopic() {
-    return properties
-        .getOrDefault(CONFLUENT_COMMAND_TOPIC_CONFIG, CONFLUENT_COMMAND_TOPIC_DEFAULT)
-        .toString();
+    return config.getString(CONFLUENT_COMMAND_TOPIC_CONFIG);
   }
 
   public String getConfluentMetricsTopic() {
-    return properties
-        .getOrDefault(CONFLUENT_METRICS_TOPIC_CONFIG, CONFLUENT_METRICS_TOPIC_DEFAULT)
-        .toString();
+    return config.getString(CONFLUENT_METRICS_TOPIC_CONFIG);
   }
 
   public String getAccessControlClassName() {
-    return properties
-        .getOrDefault(ACCESS_CONTROL_IMPLEMENTATION_CLASS, ACCESS_CONTROL_DEFAULT_CLASS)
-        .toString();
+    return config.getString(ACCESS_CONTROL_IMPLEMENTATION_CLASS);
   }
 
   public String getStateProcessorImplementationClassName() {
-    return properties
-        .getOrDefault(STATE_PROCESSOR_IMPLEMENTATION_CLASS, STATE_PROCESSOR_DEFAULT_CLASS)
-        .toString();
+    return config.getString(STATE_PROCESSOR_IMPLEMENTATION_CLASS);
   }
 
   public String getTopicPrefixFormat() {
-    return properties
-        .getOrDefault(TOPIC_PREFIX_FORMAT_CONFIG, TOPIC_PREFIX_FORMAT_DEFAULT)
-        .toString();
+    return config.getString(TOPIC_PREFIX_FORMAT_CONFIG);
   }
 
   public String getProjectPrefixFormat() {
-    return properties
-        .getOrDefault(PROJECT_PREFIX_FORMAT_CONFIG, PROJECT_PREFIX_FORMAT_DEFAULT)
-        .toString();
+    return config.getString(PROJECT_PREFIX_FORMAT_CONFIG);
   }
 
   public String getTopicPrefixSeparator() {
-    return properties
-        .getOrDefault(TOPIC_PREFIX_SEPARATOR_CONFIG, TOPIC_PREFIX_SEPARATOR_DEFAULT)
-        .toString();
+    return config.getString(TOPIC_PREFIX_SEPARATOR_CONFIG);
   }
 
   public List<String> getTopologyValidations() {
-    String[] list =
-        ((String)
-                properties.getOrDefault(TOPOLOGY_VALIDATIONS_CONFIG, TOPOLOGY_VALIDATIONS_DEFAULT))
-            .split(",");
-    return Arrays.asList(list).stream().map(v -> v.trim()).collect(Collectors.toList());
+    List<String> classes = config.getStringList(TOPOLOGY_VALIDATIONS_CONFIG);
+    return classes.stream().map(String::trim).collect(Collectors.toList());
   }
 
   public boolean allowDelete() {
@@ -272,23 +238,11 @@ public class TopologyBuilderConfig {
     return Boolean.parseBoolean(cliParams.getOrDefault(DRY_RUN_OPTION, "false"));
   }
 
-  private static Properties buildProperties(Map<String, String> cliParams) {
+  public Properties asProperties() {
     Properties props = new Properties();
-    final String adminClientConfigPath = cliParams.get(BuilderCLI.ADMIN_CLIENT_CONFIG_OPTION);
-    if (adminClientConfigPath != null) {
-      try {
-        props.load(new FileInputStream(adminClientConfigPath));
-      } catch (IOException e) {
-        System.err.println("Could not load properties file " + adminClientConfigPath);
-      }
-    }
+    config.entrySet().forEach(entry -> props.put(entry.getKey(), entry.getValue().unwrapped()));
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cliParams.get(BuilderCLI.BROKERS_OPTION));
     props.put(AdminClientConfig.RETRIES_CONFIG, Integer.MAX_VALUE);
-
     return props;
-  }
-
-  public Properties getProperties() {
-    return this.properties;
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
+++ b/src/main/java/com/purbon/kafka/topology/TopologyBuilderConfig.java
@@ -33,9 +33,9 @@ public class TopologyBuilderConfig {
       "topology.builder.state.processor.class";
 
   public static final String STATE_PROCESSOR_DEFAULT_CLASS =
-      "com.purbon.kafka.topology.clusterstate.FileBackend";
+      "com.purbon.kafka.topology.backend.FileBackend";
   public static final String REDIS_STATE_PROCESSOR_CLASS =
-      "com.purbon.kafka.topology.clusterstate.RedisBackend";
+      "com.purbon.kafka.topology.backend.RedisBackend";
 
   static final String REDIS_HOST_CONFIG = "topology.builder.redis.host";
   static final String REDIS_PORT_CONFIG = "topology.builder.redis.port";

--- a/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClientBuilder.java
+++ b/src/main/java/com/purbon/kafka/topology/api/adminclient/TopologyBuilderAdminClientBuilder.java
@@ -12,7 +12,7 @@ public class TopologyBuilderAdminClientBuilder {
   }
 
   public TopologyBuilderAdminClient build() {
-    AdminClient adminClient = AdminClient.create(config.getProperties());
+    AdminClient adminClient = AdminClient.create(config.asProperties());
     return new TopologyBuilderAdminClient(adminClient, config);
   }
 }

--- a/src/main/java/com/purbon/kafka/topology/backend/Backend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/Backend.java
@@ -1,4 +1,4 @@
-package com.purbon.kafka.topology.clusterstate;
+package com.purbon.kafka.topology.backend;
 
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;

--- a/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/FileBackend.java
@@ -1,4 +1,4 @@
-package com.purbon.kafka.topology.clusterstate;
+package com.purbon.kafka.topology.backend;
 
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.BufferedReader;

--- a/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/RedisBackend.java
@@ -1,4 +1,4 @@
-package com.purbon.kafka.topology.clusterstate;
+package com.purbon.kafka.topology.backend;
 
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;

--- a/src/main/java/com/purbon/kafka/topology/model/Impl/ProjectImpl.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Impl/ProjectImpl.java
@@ -1,7 +1,5 @@
 package com.purbon.kafka.topology.model.Impl;
 
-import static com.purbon.kafka.topology.TopologyBuilderConfig.PROJECT_PREFIX_FORMAT_DEFAULT;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.purbon.kafka.topology.TopologyBuilderConfig;
 import com.purbon.kafka.topology.model.Project;
@@ -162,8 +160,7 @@ public class ProjectImpl implements Project, Cloneable {
   }
 
   public String namePrefix() {
-    if (config.getProjectPrefixFormat().equals(PROJECT_PREFIX_FORMAT_DEFAULT))
-      return namePrefix(buildNamePrefix());
+    if (config.getProjectPrefixFormat().equals("default")) return namePrefix(buildNamePrefix());
     else return patternBasedProjectPrefix();
   }
 

--- a/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
@@ -1,7 +1,5 @@
 package com.purbon.kafka.topology.model.Impl;
 
-import static com.purbon.kafka.topology.TopologyBuilderConfig.TOPIC_PREFIX_FORMAT_DEFAULT;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -92,7 +90,7 @@ public class TopicImpl implements Topic, Cloneable {
 
   private String toString(String projectPrefix) {
     switch (appConfig.getTopicPrefixFormat()) {
-      case TOPIC_PREFIX_FORMAT_DEFAULT:
+      case "default":
         return defaultTopicStructureString(projectPrefix);
       default:
         return patternBasedTopicNameStructureString();

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -8,10 +8,10 @@ topology {
         password = "professor"
     }
     state {
-      processor.class = "com.purbon.kafka.topology.clusterstate.FileBackend"
+      processor.class = "com.purbon.kafka.topology.backend.FileBackend"
     }
     backend {
-      class = "com.purbon.kafka.topology.clusterstate.FileBackend"
+      class = "com.purbon.kafka.topology.backend.FileBackend"
     }
     redis {
       host = "localhost"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -8,10 +8,10 @@ topology {
         password = "professor"
     }
     state {
-      processor.class = "com.purbon.kafka.topology.clusterstate.FileStateProcessor"
+      processor.class = "com.purbon.kafka.topology.clusterstate.FileBackend"
     }
     backend {
-      class = "com.purbon.kafka.topology.clusterstate.FileStateProcessor"
+      class = "com.purbon.kafka.topology.clusterstate.FileBackend"
     }
     redis {
       host = "localhost"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,9 +10,6 @@ topology {
     state {
       processor.class = "com.purbon.kafka.topology.backend.FileBackend"
     }
-    backend {
-      class = "com.purbon.kafka.topology.backend.FileBackend"
-    }
     redis {
       host = "localhost"
       port = "6379"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,8 +4,6 @@ topology {
     access.control.class = "com.purbon.kafka.topology.roles.SimpleAclsProvider"
     mds {
         server = "http://localhost:8090"
-        user = "professor"
-        password = "professor"
     }
     state {
       processor.class = "com.purbon.kafka.topology.backend.FileBackend"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,50 @@
+topology {
+  validations = []
+  builder {
+    access.control.class = "com.purbon.kafka.topology.roles.SimpleAclsProvider"
+    mds {
+        server = "http://localhost:8090"
+        user = "professor"
+        password = "professor"
+    }
+    state {
+      processor.class = "com.purbon.kafka.topology.clusterstate.FileStateProcessor"
+    }
+    backend {
+      class = "com.purbon.kafka.topology.clusterstate.FileStateProcessor"
+    }
+    redis {
+      host = "localhost"
+      port = "6379"
+    }
+  }
+  topic {
+    prefix {
+      format = "default"
+      separator = "."
+    }
+  }
+  project {
+    prefix {
+      format = "default"
+    }
+  }
+}
+
+schema {
+  registry {
+    url = "mock://"
+  }
+}
+
+confluent {
+  monitoring.topic = "_confluent-monitoring"
+  command.topic = "_confluent-command"
+  metrics.topic = "_confluent-metrics"
+}
+
+kafka {
+  internal {
+      topic.prefixes = [ "_" ]
+   }
+}

--- a/src/test/java/com/purbon/kafka/topology/ClusterStateTest.java
+++ b/src/test/java/com/purbon/kafka/topology/ClusterStateTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.purbon.kafka.topology.clusterstate.FileBackend;
+import com.purbon.kafka.topology.backend.FileBackend;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.util.Collections;

--- a/src/test/java/com/purbon/kafka/topology/KafkaTopologyBuilderTest.java
+++ b/src/test/java/com/purbon/kafka/topology/KafkaTopologyBuilderTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.purbon.kafka.topology.api.adminclient.TopologyBuilderAdminClient;
-import com.purbon.kafka.topology.clusterstate.RedisBackend;
+import com.purbon.kafka.topology.backend.RedisBackend;
 import com.purbon.kafka.topology.model.Topology;
 import java.io.IOException;
 import java.net.URISyntaxException;

--- a/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopicManagerTest.java
@@ -134,7 +134,7 @@ public class TopicManagerTest {
   public void topicDeleteWithConfiguredInternalTopicsTest() throws IOException {
 
     Properties props = new Properties();
-    props.put(KAFKA_INTERNAL_TOPIC_PREFIXES, "foo.,_");
+    props.put(KAFKA_INTERNAL_TOPIC_PREFIXES, Arrays.asList("foo.", "_"));
 
     TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
 
@@ -170,7 +170,7 @@ public class TopicManagerTest {
   public void topicDeleteWithConfiguredNoDelete() throws IOException {
 
     Properties props = new Properties();
-    props.put(KAFKA_INTERNAL_TOPIC_PREFIXES, "foo.,_");
+    props.put(KAFKA_INTERNAL_TOPIC_PREFIXES, Arrays.asList("foo.", "_"));
 
     HashMap<String, String> cliOps = new HashMap<>();
     cliOps.put(BROKERS_OPTION, "");

--- a/src/test/java/com/purbon/kafka/topology/TopologyBuilderConfigTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyBuilderConfigTest.java
@@ -61,6 +61,7 @@ public class TopologyBuilderConfigTest {
     topic.setSchemas(schema);
     project.addTopic(topic);
     topology.addProject(project);
+    props.put(CONFLUENT_SCHEMA_REGISTRY_URL_CONFIG, "mock://");
 
     TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
     config.validateWith(topology);

--- a/src/test/java/com/purbon/kafka/topology/TopologyValidationTest.java
+++ b/src/test/java/com/purbon/kafka/topology/TopologyValidationTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,7 @@ public class TopologyValidationTest {
     cliOps.put(ADMIN_CLIENT_CONFIG_OPTION, "/fooBar");
 
     Properties props = new Properties();
-    props.put(TOPOLOGY_VALIDATIONS_CONFIG, "topology.CamelCaseNameFormatValidation");
+    props.put(TOPOLOGY_VALIDATIONS_CONFIG, Arrays.asList("topology.CamelCaseNameFormatValidation"));
     TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
 
     TopologyValidator validator = new TopologyValidator(config);
@@ -60,7 +61,7 @@ public class TopologyValidationTest {
     Properties props = new Properties();
     props.put(
         TOPOLOGY_VALIDATIONS_CONFIG,
-        "topology.CamelCaseNameFormatValidation, topic.PartitionNumberValidation");
+        Arrays.asList("topology.CamelCaseNameFormatValidation", "topic.PartitionNumberValidation"));
     TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
 
     TopologyValidator validator = new TopologyValidator(config);
@@ -69,8 +70,7 @@ public class TopologyValidationTest {
   }
 
   @Test
-  public void testInvalidExecutionWithFailedValidation()
-      throws IOException, URISyntaxException {
+  public void testInvalidExecutionWithFailedValidation() throws IOException, URISyntaxException {
 
     URL descriptorWithOptionals = getClass().getResource("/descriptor.yaml");
     Topology topology = parser.deserialise(Paths.get(descriptorWithOptionals.toURI()).toFile());
@@ -82,14 +82,16 @@ public class TopologyValidationTest {
     Properties props = new Properties();
     props.put(
         TOPOLOGY_VALIDATIONS_CONFIG,
-        "topology.CamelCaseNameFormatValidation, topic.PartitionNumberValidation");
+        Arrays.asList("topology.CamelCaseNameFormatValidation", "topic.PartitionNumberValidation"));
     TopologyBuilderConfig config = new TopologyBuilderConfig(cliOps, props);
 
     TopologyValidator validator = new TopologyValidator(config);
     List<String> results = validator.validate(topology);
     assertThat(results).hasSize(3);
     assertThat(results.get(0)).isEqualTo("Project name does not follow the camelCase format: foo");
-    assertThat(results.get(1)).isEqualTo("Topic contextOrg.source.foo.foo has an invalid number of partitions: 1");
-    assertThat(results.get(2)).isEqualTo("Topic contextOrg.source.bar.bar.avro has an invalid number of partitions: 1");
+    assertThat(results.get(1))
+        .isEqualTo("Topic contextOrg.source.foo.foo has an invalid number of partitions: 1");
+    assertThat(results.get(2))
+        .isEqualTo("Topic contextOrg.source.bar.bar.avro has an invalid number of partitions: 1");
   }
 }

--- a/src/test/java/com/purbon/kafka/topology/backend/RedisBackendTest.java
+++ b/src/test/java/com/purbon/kafka/topology/backend/RedisBackendTest.java
@@ -1,7 +1,7 @@
-package com.purbon.kafka.topology.clusterstate;
+package com.purbon.kafka.topology.backend;
 
-import static com.purbon.kafka.topology.clusterstate.RedisBackend.KAFKA_TOPOLOGY_BUILDER_BINDINGS;
-import static com.purbon.kafka.topology.clusterstate.RedisBackend.KAFKA_TOPOLOGY_BUILDER_TYPE;
+import static com.purbon.kafka.topology.backend.RedisBackend.KAFKA_TOPOLOGY_BUILDER_BINDINGS;
+import static com.purbon.kafka.topology.backend.RedisBackend.KAFKA_TOPOLOGY_BUILDER_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;

--- a/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
+++ b/src/test/java/com/purbon/kafka/topology/integration/backend/RedisBackendIT.java
@@ -1,6 +1,6 @@
-package com.purbon.kafka.topology.integration.clusterstate;
+package com.purbon.kafka.topology.integration.backend;
 
-import com.purbon.kafka.topology.clusterstate.RedisBackend;
+import com.purbon.kafka.topology.backend.RedisBackend;
 import com.purbon.kafka.topology.roles.TopologyAclBinding;
 import java.io.IOException;
 import java.util.Arrays;

--- a/src/test/resources/client-config-redis.properties
+++ b/src/test/resources/client-config-redis.properties
@@ -5,6 +5,6 @@ sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule require
   password="kafka";
 schema.registry.url="http://localhost:8082"
 
-topology.builder.state.processor.class=com.purbon.kafka.topology.clusterstate.RedisBackend
+topology.builder.state.processor.class=com.purbon.kafka.topology.backend.RedisBackend
 topology.builder.redis.host=foo
 topology.builder.redis.port=9999


### PR DESCRIPTION
This Pull Request adds support for:

* the lightbend config library.

This library give support for:

* better default values management.
* support for environment variables as configuration replacements.
* support for json, yaml and hacon files as well as property files for configs.
* made the broker config optional if the config one is specified.

more references at: https://github.com/lightbend/config

closes #88 #82 